### PR TITLE
ci: emit the `gate` context the org ruleset requires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,29 @@ jobs:
       repo: ${{ github.event.repository.name }}
     secrets: inherit
 
+
+  # The paiml org ruleset "Green Main — unified gate enforcement" requires a
+  # status context named exactly `gate`. Repos that define their CI jobs
+  # directly (e.g. paiml/infra) emit that name naturally. ruchy CALLS the
+  # reusable sovereign-ci workflow, so its aggregate job reports as `ci / gate`
+  # — a different context — and the required `gate` check therefore NEVER
+  # appeared on any ruchy PR. The requirement was permanently unsatisfiable:
+  # every PR sat at mergeStateStatus=BLOCKED with "the base branch policy
+  # prohibits the merge", and the only way anything landed was an admin bypass.
+  #
+  # This job re-exports the reusable workflow's verdict under the org's
+  # expected name. It does not weaken the gate: it fails whenever the called
+  # workflow does not succeed. Modelled on paiml/infra's ci.yml gate job.
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [ci]
+    steps:
+      - name: Check called workflow result
+        run: |
+          if [ "${{ needs.ci.result }}" != "success" ]; then
+            echo "::error::sovereign-ci did not succeed (result: ${{ needs.ci.result }})"
+            exit 1
+          fi
+          echo "sovereign-ci succeeded"


### PR DESCRIPTION
**Every ruchy PR has been unmergeable, and not because of its own CI.**

The paiml org ruleset *"Green Main — unified gate enforcement"* requires a status context named exactly **`gate`**. Repos that define their CI jobs directly (`paiml/infra`) emit that name naturally. ruchy **calls** the reusable `sovereign-ci` workflow, so its aggregate job reports as **`ci / gate`** — a different context string — and the required `gate` check therefore never appeared on any ruchy PR at all.

Verified on #197 and #194 — `statusCheckRollup` lists:

```
authorize / authorize   ci / gate      ci / test        ci / lint
ci / coverage           ci / security  ci / provenance  ci / bench
Security Audit          Baseline Comparison             Performance Benchmarks
```

…and **no bare `gate`**. The requirement was permanently unsatisfiable, so every PR sat at `mergeStateStatus=BLOCKED` with *"the base branch policy prohibits the merge"*. #194 shows the identical profile and merged anyway, which means it went in by admin bypass — the ruleset grants `OrganizationAdmin` `bypass_mode: always`.

That is **a required check that can never pass** — the mirror image of the gates fixed in paiml/paiml-mcp-agent-toolkit#916, which always passed and could never fail.

## Why fixed here and not in the ruleset

The ruleset is **organization-scoped** (`source_type: Organization`, `source: paiml`). Changing its required context to `ci / gate` would apply to **every paiml repo** and would break `paiml/infra`, where bare `gate` is the correct and currently-working name. Making ruchy conform to the org standard is the smaller, safer change.

## It does not weaken enforcement

The job fails whenever the called workflow does not succeed. Modelled directly on `paiml/infra`'s `ci.yml` gate job.

This PR is self-satisfying: the new job runs on this PR, so the `gate` context appears and can be checked before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)