### PR TITLE
fix(features): minimal and all-features targets compile; REPL tests and targets declare their feature [PMAT-113]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,6 +247,7 @@ autobins = false
 [[bin]]
 name = "ruchy"
 path = "src/bin/ruchy.rs"
+required-features = ["repl"]
 
 
 [lib]
@@ -273,7 +274,7 @@ visualization = ["dep:trueno-viz"]
 infra = ["dep:forjar"]
 simulation = ["dep:simular"]
 shell-target = ["dep:bashrs"]
-minimal = []  # Users can use --no-default-features --features minimal for core only
+minimal = []  # core library only (--no-default-features --features minimal); the ruchy binary requires the repl feature
 # DataFrame via trueno-db (default - uses Trueno SIMD backend)
 dataframe = ["polars", "arrow"]
 # Legacy polars compatibility layer (spec Section 4.2 - NOT default)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -439,6 +439,7 @@ harness = false
 
 [[bench]]
 name = "interpreter_benchmarks"
+required-features = ["repl"]
 harness = false
 
 [[bench]]
@@ -463,6 +464,7 @@ harness = false
 
 [[bench]]
 name = "matrix_data_science_benchmarks"
+required-features = ["repl"]
 harness = false
 
 # Commented out due to compilation errors
@@ -598,3 +600,40 @@ rustdoc-args = ["--generate-link-to-definition"]
 [build-dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_yaml_ng = "0.10"
+
+[[bench]]
+name = "execution_bench"
+harness = false
+required-features = ["repl"]
+
+[[example]]
+name = "dataframe_pipeline"
+required-features = ["repl"]
+
+[[example]]
+name = "reference_demo"
+required-features = ["repl"]
+
+[[example]]
+name = "repl_control_flow"
+required-features = ["repl"]
+
+[[example]]
+name = "repl_basic_arithmetic"
+required-features = ["repl"]
+
+[[example]]
+name = "function_calls"
+required-features = ["repl"]
+
+[[example]]
+name = "test_string_methods"
+required-features = ["repl"]
+
+[[example]]
+name = "repl_variables_and_functions"
+required-features = ["repl"]
+
+[[example]]
+name = "test_mutation"
+required-features = ["repl"]

--- a/contracts/test-feature-gates-v1.yaml
+++ b/contracts/test-feature-gates-v1.yaml
@@ -1,0 +1,70 @@
+metadata:
+  version: "1.0.0"
+  author: "Sovereign AI Stack"
+  description: "Feature-gate contract for the test tree and the ruchy binary: every advertised feature set compiles every target it enables (PMAT-112, PMAT-113)"
+  crate: "ruchy"
+  references:
+    - "docs/specifications/ruchy-5.0.0-beta.2-release-plan.md §2 Z5 (pre-release gate, stage 2 features)"
+    - "contracts/feature-matrix-v1.yaml (PMAT-101)"
+    - "Cargo reference: [[bin]] required-features"
+
+equations:
+  minimal_compiles_every_enabled_target:
+    formula: "∀ t ∈ targets(ruchy): required_features(t) ⊆ enabled(minimal) ⇒ clippy(t, minimal) = 0"
+    domain: "cargo clippy --all-targets --no-default-features --features minimal -- -D warnings"
+    invariants:
+      - "A test target that imports ruchy::runtime::repl carries #[cfg(feature = \"repl\")] at crate or item level"
+      - "The ruchy binary declares required-features = [\"repl\"]; minimal is the core library only"
+      - "default = batteries-included enables repl, so cargo install ruchy still builds the binary"
+  no_discarded_must_use:
+    formula: "∀ s ∈ statements(tests): s = <assert_cmd chain>.assert(); ⇒ bound(s) ∨ wrapped(s, assert_args_accepted)"
+    domain: "tests/**/*.rs"
+    invariants:
+      - "cargo clippy --all-targets --all-features -- -D warnings reports no must_use error in a feature-gated test target"
+
+proof_obligations:
+  - type: completeness
+    property: "Every feature set in {default, all, minimal} compiles every target it enables"
+    formal: "minimal_compiles_every_enabled_target ∧ no_discarded_must_use"
+    applies_to: all
+
+falsification_tests:
+  - id: FALSIFY-TEST-FEATURE-GATES-001
+    rule: "REPL tests are feature-gated"
+    test: "test_pmat_113_repl_tests_are_feature_gated"
+    prediction: "verified"
+    if_fails: "Contract violation — a test target imports the REPL without a gate and breaks the minimal build"
+  - id: FALSIFY-TEST-FEATURE-GATES-002
+    rule: "The binary names the feature it needs"
+    test: "test_pmat_113_ruchy_binary_requires_the_repl_feature"
+    prediction: "verified"
+    if_fails: "Contract violation — cargo check --features minimal fails inside src/bin instead of skipping the binary"
+  - id: FALSIFY-TEST-FEATURE-GATES-003
+    rule: "The default build still ships the binary"
+    test: "test_pmat_113_default_features_enable_repl"
+    prediction: "verified"
+    if_fails: "Contract violation — cargo install ruchy produces no binary"
+  - id: FALSIFY-TEST-FEATURE-GATES-004
+    rule: "No discarded must_use assert"
+    test: "test_pmat_112_no_bare_assert_statements_in_tests"
+    prediction: "verified"
+    if_fails: "Contract violation — clippy --all-features turns red on a target CI never compiles"
+
+kani_harnesses:
+  - id: KANI-TEST-FEATURE-GATES-001
+    obligation: PO-TEST-FEATURE-GATES-001
+    property: "minimal_compiles_every_enabled_target"
+    bound: 8
+    strategy: bounded_int
+    harness: verify_test_feature_gates
+
+qa_gate:
+  id: QA-TEST-FEATURE-GATES
+  name: "test feature gates contract"
+  min_coverage: 0.90
+  max_complexity: 10
+  required_tests:
+    - "test_pmat_113_repl_tests_are_feature_gated"
+    - "test_pmat_113_ruchy_binary_requires_the_repl_feature"
+    - "test_pmat_113_default_features_enable_repl"
+    - "test_pmat_112_no_bare_assert_statements_in_tests"

--- a/contracts/test-feature-gates-v1.yaml
+++ b/contracts/test-feature-gates-v1.yaml
@@ -35,20 +35,50 @@ falsification_tests:
     prediction: "verified"
     if_fails: "Contract violation — a test target imports the REPL without a gate and breaks the minimal build"
   - id: FALSIFY-TEST-FEATURE-GATES-002
+    rule: "REPL examples and benches declare required-features"
+    test: "test_pmat_113_repl_examples_and_benches_declare_required_features"
+    prediction: "verified"
+    if_fails: "Contract violation — cargo clippy --all-targets --features minimal fails inside an example or bench"
+  - id: FALSIFY-TEST-FEATURE-GATES-003
     rule: "The binary names the feature it needs"
     test: "test_pmat_113_ruchy_binary_requires_the_repl_feature"
     prediction: "verified"
     if_fails: "Contract violation — cargo check --features minimal fails inside src/bin instead of skipping the binary"
-  - id: FALSIFY-TEST-FEATURE-GATES-003
+  - id: FALSIFY-TEST-FEATURE-GATES-004
     rule: "The default build still ships the binary"
     test: "test_pmat_113_default_features_enable_repl"
     prediction: "verified"
     if_fails: "Contract violation — cargo install ruchy produces no binary"
-  - id: FALSIFY-TEST-FEATURE-GATES-004
+  - id: FALSIFY-TEST-FEATURE-GATES-005
     rule: "No discarded must_use assert"
     test: "test_pmat_112_no_bare_assert_statements_in_tests"
     prediction: "verified"
     if_fails: "Contract violation — clippy --all-features turns red on a target CI never compiles"
+  - id: FALSIFY-TEST-FEATURE-GATES-006
+    rule: "The gate scan discriminates gated from ungated REPL uses"
+    test: "test_pmat_113_lint_discriminates_gated_from_ungated_repl_uses"
+    prediction: "verified"
+    if_fails: "Lint defect — a crate-level or item-level gate is not recognised, or a missing gate is"
+  - id: FALSIFY-TEST-FEATURE-GATES-007
+    rule: "The gate scan sees every import spelling and ignores comments and strings"
+    test: "test_pmat_113_lint_sees_through_import_spellings_and_ignores_prose"
+    prediction: "verified"
+    if_fails: "Lint defect — a glob, multi-line or self import evades the scan, or prose triggers it"
+  - id: FALSIFY-TEST-FEATURE-GATES-008
+    rule: "The assert scan discriminates bare from consumed values"
+    test: "test_pmat_112_lint_discriminates_bare_from_consumed_asserts"
+    prediction: "verified"
+    if_fails: "Lint defect — a bound, returned, wrapped or mockito assert is flagged, or a bare one is missed"
+  - id: FALSIFY-TEST-FEATURE-GATES-009
+    rule: "The manifest scan reads target tables"
+    test: "test_pmat_113_manifest_target_parser_reads_name_and_required_features"
+    prediction: "verified"
+    if_fails: "Lint defect — required-features on a declared target is not read"
+  - id: FALSIFY-TEST-FEATURE-GATES-010
+    rule: "REPL type names are read from the gated module"
+    test: "test_pmat_113_repl_type_names_come_from_the_gated_module"
+    prediction: "verified"
+    if_fails: "Lint defect — the scan would miss Repl, ReplState or ReplMode, or count wasm::ReplOutput"
 
 kani_harnesses:
   - id: KANI-TEST-FEATURE-GATES-001
@@ -65,6 +95,12 @@ qa_gate:
   max_complexity: 10
   required_tests:
     - "test_pmat_113_repl_tests_are_feature_gated"
+    - "test_pmat_113_repl_examples_and_benches_declare_required_features"
     - "test_pmat_113_ruchy_binary_requires_the_repl_feature"
     - "test_pmat_113_default_features_enable_repl"
     - "test_pmat_112_no_bare_assert_statements_in_tests"
+    - "test_pmat_113_lint_discriminates_gated_from_ungated_repl_uses"
+    - "test_pmat_113_lint_sees_through_import_spellings_and_ignores_prose"
+    - "test_pmat_112_lint_discriminates_bare_from_consumed_asserts"
+    - "test_pmat_113_manifest_target_parser_reads_name_and_required_features"
+    - "test_pmat_113_repl_type_names_come_from_the_gated_module"

--- a/tests/cli_contract_notebook.rs
+++ b/tests/cli_contract_notebook.rs
@@ -23,6 +23,9 @@ use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
 
+mod support;
+use support::assert_args_accepted;
+
 /// Helper: Create ruchy command
 fn ruchy_cmd() -> Command {
     assert_cmd::cargo::cargo_bin_cmd!("ruchy")
@@ -88,12 +91,14 @@ fn cli_notebook_validate_outputs_success_message() {
 
 #[test]
 fn cli_notebook_custom_port() {
-    ruchy_cmd()
-        .arg("notebook")
-        .arg("--port")
-        .arg("9090")
-        .timeout(std::time::Duration::from_secs(2))
-        .assert(); // Will timeout but tests port parsing
+    assert_args_accepted(
+        ruchy_cmd()
+            .arg("notebook")
+            .arg("--port")
+            .arg("9090")
+            .timeout(std::time::Duration::from_secs(2))
+            .assert(), // Will timeout but tests port parsing
+    );
 }
 
 #[test]
@@ -122,22 +127,26 @@ fn cli_notebook_port_out_of_range() {
 
 #[test]
 fn cli_notebook_custom_host() {
-    ruchy_cmd()
-        .arg("notebook")
-        .arg("--host")
-        .arg("0.0.0.0")
-        .timeout(std::time::Duration::from_secs(2))
-        .assert(); // Will timeout but tests host parsing
+    assert_args_accepted(
+        ruchy_cmd()
+            .arg("notebook")
+            .arg("--host")
+            .arg("0.0.0.0")
+            .timeout(std::time::Duration::from_secs(2))
+            .assert(), // Will timeout but tests host parsing
+    );
 }
 
 #[test]
 fn cli_notebook_localhost_host() {
-    ruchy_cmd()
-        .arg("notebook")
-        .arg("--host")
-        .arg("localhost")
-        .timeout(std::time::Duration::from_secs(2))
-        .assert();
+    assert_args_accepted(
+        ruchy_cmd()
+            .arg("notebook")
+            .arg("--host")
+            .arg("localhost")
+            .timeout(std::time::Duration::from_secs(2))
+            .assert(),
+    );
 }
 
 // ============================================================================
@@ -147,11 +156,13 @@ fn cli_notebook_localhost_host() {
 #[test]
 #[ignore = "Opens browser - slow test, run in tier3-nightly"]
 fn cli_notebook_open_browser_flag() {
-    ruchy_cmd()
-        .arg("notebook")
-        .arg("--open")
-        .timeout(std::time::Duration::from_secs(2))
-        .assert(); // Will timeout but tests --open flag
+    assert_args_accepted(
+        ruchy_cmd()
+            .arg("notebook")
+            .arg("--open")
+            .timeout(std::time::Duration::from_secs(2))
+            .assert(), // Will timeout but tests --open flag
+    );
 }
 
 // ============================================================================

--- a/tests/critical_regressions.rs
+++ b/tests/critical_regressions.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![cfg(test)]
 #![allow(missing_docs)]
 #![allow(warnings)]

--- a/tests/critical_repl_features.rs
+++ b/tests/critical_repl_features.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![cfg(test)]
 #![allow(missing_docs)]
 #![allow(warnings)]

--- a/tests/feature_gate_lint.rs
+++ b/tests/feature_gate_lint.rs
@@ -19,6 +19,10 @@ fn test_sources() -> Vec<(PathBuf, String)> {
         .flatten()
         .map(|entry| entry.path())
         .filter(|path| path.extension().is_some_and(|ext| ext == "rs"))
+        .filter(|path| {
+            path.file_name()
+                .is_some_and(|name| name != "feature_gate_lint.rs")
+        })
         .collect();
     files.sort();
     files
@@ -66,18 +70,40 @@ fn ungated_repl_uses(path: &Path, src: &str) -> Vec<String> {
         .collect()
 }
 
-/// `....assert();` as a bare statement discards a `#[must_use]` value, which
-/// is a clippy error under `-D warnings` once the target's feature is on.
-fn is_bare_assert_statement(line: &str) -> bool {
-    let code = line.split("//").next().unwrap_or_default().trim();
-    code.ends_with(".assert();") && !code.contains("let ") && !code.contains('=')
+/// Index of the first line of the statement that ends at `idx`: the line after
+/// the nearest earlier line that closes a statement or block, or is blank.
+fn statement_start(lines: &[&str], idx: usize) -> usize {
+    (0..idx)
+        .rev()
+        .find(|&i| {
+            let code = lines[i].split("//").next().unwrap_or_default().trim();
+            code.is_empty() || code.ends_with(';') || code.ends_with('{') || code.ends_with('}')
+        })
+        .map_or(0, |i| i + 1)
+}
+
+/// A statement that ends in `.assert();` and neither binds nor otherwise
+/// consumes the `assert_cmd::assert::Assert` it produces discards a
+/// `#[must_use]` value: a clippy error under `-D warnings` once the target's
+/// feature is on. Only `assert_cmd` chains count (mockito's `Mock::assert`
+/// returns unit).
+fn is_bare_assert_statement(lines: &[&str], idx: usize) -> bool {
+    let last = lines[idx].split("//").next().unwrap_or_default().trim();
+    if !last.ends_with(".assert();") {
+        return false;
+    }
+    let statement = lines[statement_start(lines, idx)..=idx].join("\n");
+    let from_assert_cmd = statement.contains("ruchy_cmd(")
+        || statement.contains("cargo_bin")
+        || statement.contains("Command::");
+    from_assert_cmd && !statement.contains("let ") && !statement.contains(" = ")
 }
 
 fn bare_assert_statements(path: &Path, src: &str) -> Vec<String> {
-    src.lines()
-        .enumerate()
-        .filter(|(_, line)| is_bare_assert_statement(line))
-        .map(|(idx, line)| format!("{}:{}: {}", path.display(), idx + 1, line.trim()))
+    let lines: Vec<&str> = src.lines().collect();
+    (0..lines.len())
+        .filter(|&idx| is_bare_assert_statement(&lines, idx))
+        .map(|idx| format!("{}:{}: {}", path.display(), idx + 1, lines[idx].trim()))
         .collect()
 }
 
@@ -125,9 +151,77 @@ fn test_pmat_113_lint_discriminates_gated_from_ungated_repl_uses() {
 
 #[test]
 fn test_pmat_112_lint_discriminates_bare_from_consumed_asserts() {
-    assert!(is_bare_assert_statement("        .assert(); // times out"));
-    assert!(is_bare_assert_statement("    cmd.assert();"));
-    assert!(!is_bare_assert_statement("            .assert(),"));
-    assert!(!is_bare_assert_statement("    let out = cmd.assert();"));
-    assert!(!is_bare_assert_statement("        .assert()"));
+    let bare = [
+        "fn t() {",
+        "    ruchy_cmd()",
+        "        .arg(\"x\")",
+        "        .assert(); // times out",
+        "}",
+    ];
+    assert!(is_bare_assert_statement(&bare, 3));
+    let bound = [
+        "fn t() {",
+        "    let out = ruchy_cmd()",
+        "        .arg(\"x\")",
+        "        .assert();",
+        "}",
+    ];
+    assert!(!is_bare_assert_statement(&bound, 3));
+    let wrapped = [
+        "    assert_args_accepted(",
+        "        ruchy_cmd()",
+        "            .assert(),",
+        "    );",
+    ];
+    assert!(!is_bare_assert_statement(&wrapped, 2));
+    let mockito = [
+        "    let mock = server.mock(\"GET\", \"/\");",
+        "    mock.assert();",
+    ];
+    assert!(!is_bare_assert_statement(&mockito, 1));
+}
+
+/// The `[[bin]]` block of the ruchy binary in the crate manifest.
+fn ruchy_bin_block() -> String {
+    let manifest = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+        .expect("Cargo.toml is readable");
+    manifest
+        .split("[[bin]]")
+        .skip(1)
+        .map(|block| block.split("\n[").next().unwrap_or_default())
+        .find(|block| block.contains("name = \"ruchy\""))
+        .expect("Cargo.toml declares [[bin]] ruchy")
+        .to_string()
+}
+
+/// `minimal` is the core library only; the binary is a REPL-driven CLI, so it
+/// must say so instead of failing to compile under `--features minimal`.
+#[test]
+fn test_pmat_113_ruchy_binary_requires_the_repl_feature() {
+    let block = ruchy_bin_block();
+    let required = block
+        .lines()
+        .find(|line| line.trim_start().starts_with("required-features"))
+        .unwrap_or_default();
+    assert!(
+        required.contains("\"repl\""),
+        "[[bin]] ruchy must declare required-features = [\"repl\"]; found: {required:?}"
+    );
+}
+
+/// And the default build must still produce the binary.
+#[test]
+fn test_pmat_113_default_features_enable_repl() {
+    let manifest = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+        .expect("Cargo.toml is readable");
+    let batteries = manifest
+        .lines()
+        .find(|line| line.starts_with("batteries-included"))
+        .expect("batteries-included feature");
+    let default = manifest
+        .lines()
+        .find(|line| line.starts_with("default"))
+        .expect("default feature");
+    assert!(default.contains("\"batteries-included\""), "{default}");
+    assert!(batteries.contains("\"repl\""), "{batteries}");
 }

--- a/tests/feature_gate_lint.rs
+++ b/tests/feature_gate_lint.rs
@@ -1,24 +1,27 @@
 #![allow(missing_docs)]
 //! Feature-gate lint for the integration test tree (PMAT-112, PMAT-113).
 //!
-//! The gate is `cargo check --tests --no-default-features --features minimal`
+//! The gate is `cargo clippy --all-targets --no-default-features --features minimal`
 //! together with `cargo clippy --all-targets --all-features -- -D warnings`.
 //! These tests are the fast discriminator: they name the offending file and
 //! line in milliseconds instead of after a full feature-matrix build.
+//!
+//! Detection works on source with comments and string literals stripped, and
+//! on identifier tokens that are declared under `src/runtime/repl`, so a glob
+//! or multi-line `use` does not evade it, a mention in a comment does not
+//! trigger it, and unrelated names such as `wasm::ReplOutput` do not count.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const REPL_GATE: &str = "#[cfg(feature = \"repl\")]";
-const FILE_GATE_PREFIX: &str = "#![cfg(feature = ";
 
-fn test_sources() -> Vec<(PathBuf, String)> {
-    sources_in("tests")
+fn crate_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
 }
 
 fn sources_in(dir: &str) -> Vec<(PathBuf, String)> {
-    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(dir);
-    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
+    let mut files: Vec<PathBuf> = fs::read_dir(crate_path(dir))
         .expect("source directory is readable")
         .flatten()
         .map(|entry| entry.path())
@@ -32,43 +35,167 @@ fn sources_in(dir: &str) -> Vec<(PathBuf, String)> {
     files
         .into_iter()
         .map(|path| {
-            let src = fs::read_to_string(&path).expect("test source is readable");
+            let src = fs::read_to_string(&path).expect("source is readable");
             (path, src)
         })
         .collect()
 }
 
-/// A line that pulls the REPL into the test target.
-fn line_references_repl(line: &str) -> bool {
-    line.contains("runtime::Repl")
-        || line.contains("runtime::repl")
-        || (line.contains("runtime::{") && line.contains("Repl"))
+fn stem_of(path: &Path) -> String {
+    path.file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned()
 }
 
-/// A crate-level `#![cfg(feature = "...")]` keeps the whole target out of
-/// the `minimal` build, whichever feature it names.
-fn has_file_level_feature_gate(src: &str) -> bool {
-    src.lines().any(|line| line.starts_with(FILE_GATE_PREFIX))
+/// One line of code with its `//` comment and the contents of its string
+/// literals removed (escaped quotes inside a literal are honoured).
+fn code_only(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    let mut in_string = false;
+    while let Some(c) = chars.next() {
+        match (in_string, c) {
+            (true, '\\') => {
+                chars.next();
+            }
+            (true, '"') => in_string = false,
+            (true, _) => {}
+            (false, '"') => in_string = true,
+            (false, '/') if chars.peek() == Some(&'/') => break,
+            (false, _) => out.push(c),
+        }
+    }
+    out
 }
 
-/// An item-level `#[cfg(feature = "repl")]` within the four lines above the
-/// use (attribute, `#[test]`, `fn` header, then the `use` inside the body).
-fn item_gated_above(lines: &[&str], idx: usize) -> bool {
-    let start = idx.saturating_sub(4);
-    lines[start..idx]
+fn is_ident_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// The source with every `/* ... */` block comment blanked out; newlines are
+/// kept so line numbers still refer to the original file.
+fn without_block_comments(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut rest = src;
+    while let Some(start) = rest.find("/*") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let end = after.find("*/").map_or(after.len(), |n| n + 2);
+        out.extend(after[..end].chars().filter(|c| *c == '\n'));
+        rest = &after[end..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// `pub struct|enum|trait|type Repl…` on one line, if any.
+fn declared_repl_type(line: &str) -> Option<String> {
+    let rest = line.trim_start().strip_prefix("pub ")?;
+    let rest = ["struct ", "enum ", "trait ", "type "]
         .iter()
-        .any(|line| line.trim() == REPL_GATE)
+        .find_map(|keyword| rest.strip_prefix(keyword))?;
+    let name: String = rest.chars().take_while(|c| is_ident_char(*c)).collect();
+    name.starts_with("Repl").then_some(name)
 }
 
-fn ungated_repl_uses(path: &Path, src: &str) -> Vec<String> {
+fn collect_repl_types(dir: &Path, names: &mut Vec<String>) {
+    for entry in fs::read_dir(dir)
+        .expect("src/runtime/repl is readable")
+        .flatten()
+    {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_repl_types(&path, names);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            let src = fs::read_to_string(&path).expect("module source is readable");
+            names.extend(src.lines().filter_map(declared_repl_type));
+        }
+    }
+}
+
+/// Public `Repl…` types declared under `src/runtime/repl`, the feature-gated
+/// module. Names from elsewhere (`wasm::ReplOutput`, `WasmRepl`) are absent.
+fn repl_type_names() -> Vec<String> {
+    let mut names = Vec::new();
+    collect_repl_types(&crate_path("src/runtime/repl"), &mut names);
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// The identifier that starts at byte `idx` of `code`, if `idx` starts one.
+fn identifier_at(code: &str, idx: usize) -> Option<&str> {
+    let before = code[..idx].chars().next_back();
+    if before.is_some_and(is_ident_char) {
+        return None;
+    }
+    let end = code[idx..]
+        .find(|c: char| !is_ident_char(c))
+        .map_or(code.len(), |n| idx + n);
+    Some(&code[idx..end])
+}
+
+/// A line that pulls the REPL into the target: a `runtime::repl` path or a
+/// whole-word use of a type declared in that module.
+fn line_references_repl(line: &str, names: &[String]) -> bool {
+    let code = code_only(line);
+    code.contains("runtime::repl")
+        || code
+            .match_indices("Repl")
+            .filter_map(|(idx, _)| identifier_at(&code, idx))
+            .any(|word| names.iter().any(|name| name == word))
+}
+
+/// A `cfg` attribute, plain or inside `all(...)`, that names the `repl` feature.
+fn names_repl_feature(attribute: &str) -> bool {
+    attribute.starts_with('#')
+        && attribute.contains("cfg(")
+        && attribute.contains("feature = \"repl\"")
+}
+
+/// A crate-level `#![cfg(feature = "...")]`, or `#![cfg(all(..., feature = "..."))]`,
+/// keeps the whole target out of the `minimal` build, whichever feature it names.
+fn has_file_level_feature_gate(src: &str) -> bool {
+    src.lines()
+        .any(|line| line.starts_with("#![cfg(") && line.contains("feature = \""))
+}
+
+/// Index of the column-0 `fn` header that encloses line `idx`, if any.
+fn enclosing_fn_header(lines: &[&str], idx: usize) -> Option<usize> {
+    (0..=idx).rev().find(|&i| {
+        let line = lines[i];
+        !line.starts_with(char::is_whitespace) && (line.starts_with("fn ") || line.contains(" fn "))
+    })
+}
+
+/// The outer attribute block directly above `header` carries the REPL gate.
+fn attributes_gate(lines: &[&str], header: usize) -> bool {
+    (0..header)
+        .rev()
+        .map(|i| lines[i].trim())
+        .take_while(|line| line.starts_with("#["))
+        .any(names_repl_feature)
+}
+
+/// An item-level `#[cfg(feature = "repl")]`: either directly above the line
+/// (a gated `use` item) or on the function whose body contains it.
+fn item_gated_above(lines: &[&str], idx: usize) -> bool {
+    let directly_above = idx > 0 && names_repl_feature(lines[idx - 1].trim());
+    directly_above
+        || enclosing_fn_header(lines, idx).is_some_and(|header| attributes_gate(lines, header))
+}
+
+fn ungated_repl_uses(path: &Path, src: &str, names: &[String]) -> Vec<String> {
     if has_file_level_feature_gate(src) {
         return Vec::new();
     }
+    let src = without_block_comments(src);
     let lines: Vec<&str> = src.lines().collect();
     lines
         .iter()
         .enumerate()
-        .filter(|(_, line)| line_references_repl(line))
+        .filter(|(_, line)| line_references_repl(line, names))
         .filter(|(idx, _)| !item_gated_above(&lines, *idx))
         .map(|(idx, line)| format!("{}:{}: {}", path.display(), idx + 1, line.trim()))
         .collect()
@@ -80,30 +207,39 @@ fn statement_start(lines: &[&str], idx: usize) -> usize {
     (0..idx)
         .rev()
         .find(|&i| {
-            let code = lines[i].split("//").next().unwrap_or_default().trim();
+            let code = code_only(lines[i]);
+            let code = code.trim();
             code.is_empty() || code.ends_with(';') || code.ends_with('{') || code.ends_with('}')
         })
         .map_or(0, |i| i + 1)
 }
 
-/// A statement that ends in `.assert();` and neither binds nor otherwise
-/// consumes the `assert_cmd::assert::Assert` it produces discards a
+/// A statement that ends in `.assert();` and neither binds, returns nor
+/// otherwise consumes the `assert_cmd::assert::Assert` it produces discards a
 /// `#[must_use]` value: a clippy error under `-D warnings` once the target's
 /// feature is on. Only `assert_cmd` chains count (mockito's `Mock::assert`
 /// returns unit).
 fn is_bare_assert_statement(lines: &[&str], idx: usize) -> bool {
-    let last = lines[idx].split("//").next().unwrap_or_default().trim();
-    if !last.ends_with(".assert();") {
+    let compact: String = code_only(lines[idx]).split_whitespace().collect();
+    if !compact.ends_with(".assert();") {
         return false;
     }
-    let statement = lines[statement_start(lines, idx)..=idx].join("\n");
+    let statement: String = lines[statement_start(lines, idx)..=idx]
+        .iter()
+        .map(|line| code_only(line))
+        .collect::<Vec<_>>()
+        .join("\n");
     let from_assert_cmd = statement.contains("ruchy_cmd(")
         || statement.contains("cargo_bin")
         || statement.contains("Command::");
-    from_assert_cmd && !statement.contains("let ") && !statement.contains(" = ")
+    let consumed = statement.contains("let ")
+        || statement.contains(" = ")
+        || statement.trim_start().starts_with("return ");
+    from_assert_cmd && !consumed
 }
 
 fn bare_assert_statements(path: &Path, src: &str) -> Vec<String> {
+    let src = without_block_comments(src);
     let lines: Vec<&str> = src.lines().collect();
     (0..lines.len())
         .filter(|&idx| is_bare_assert_statement(&lines, idx))
@@ -111,128 +247,8 @@ fn bare_assert_statements(path: &Path, src: &str) -> Vec<String> {
         .collect()
 }
 
-#[test]
-fn test_pmat_113_repl_tests_are_feature_gated() {
-    let violations: Vec<String> = test_sources()
-        .iter()
-        .flat_map(|(path, src)| ungated_repl_uses(path, src))
-        .collect();
-    assert!(
-        violations.is_empty(),
-        "REPL-dependent tests must carry `{REPL_GATE}` (crate-level `#!` form or on the item) \
-         so that `--no-default-features --features minimal` compiles:\n{}",
-        violations.join("\n")
-    );
-}
-
-#[test]
-fn test_pmat_112_no_bare_assert_statements_in_tests() {
-    let violations: Vec<String> = test_sources()
-        .iter()
-        .flat_map(|(path, src)| bare_assert_statements(path, src))
-        .collect();
-    assert!(
-        violations.is_empty(),
-        "bare `.assert();` statements discard a must_use value; wrap them in \
-         `support::assert_args_accepted(..)` or assert on the result:\n{}",
-        violations.join("\n")
-    );
-}
-
-#[test]
-fn test_pmat_113_lint_discriminates_gated_from_ungated_repl_uses() {
-    let path = Path::new("x.rs");
-    let ungated = "use ruchy::runtime::Repl;\n#[test]\nfn t() {}\n";
-    assert_eq!(ungated_repl_uses(path, ungated).len(), 1);
-    let file_gated = format!("#![cfg(feature = \"repl\")]\n{ungated}");
-    assert!(ungated_repl_uses(path, &file_gated).is_empty());
-    let item_gated =
-        "#[cfg(feature = \"repl\")]\n#[test]\nfn t() {\n    use ruchy::runtime::repl::state::ReplState;\n}\n";
-    assert!(ungated_repl_uses(path, item_gated).is_empty());
-    let too_far = "#[cfg(feature = \"repl\")]\n\n\n\n\nuse ruchy::runtime::Repl;\n";
-    assert_eq!(ungated_repl_uses(path, too_far).len(), 1);
-}
-
-#[test]
-fn test_pmat_112_lint_discriminates_bare_from_consumed_asserts() {
-    let bare = [
-        "fn t() {",
-        "    ruchy_cmd()",
-        "        .arg(\"x\")",
-        "        .assert(); // times out",
-        "}",
-    ];
-    assert!(is_bare_assert_statement(&bare, 3));
-    let bound = [
-        "fn t() {",
-        "    let out = ruchy_cmd()",
-        "        .arg(\"x\")",
-        "        .assert();",
-        "}",
-    ];
-    assert!(!is_bare_assert_statement(&bound, 3));
-    let wrapped = [
-        "    assert_args_accepted(",
-        "        ruchy_cmd()",
-        "            .assert(),",
-        "    );",
-    ];
-    assert!(!is_bare_assert_statement(&wrapped, 2));
-    let mockito = [
-        "    let mock = server.mock(\"GET\", \"/\");",
-        "    mock.assert();",
-    ];
-    assert!(!is_bare_assert_statement(&mockito, 1));
-}
-
-/// The `[[bin]]` block of the ruchy binary in the crate manifest.
-fn ruchy_bin_block() -> String {
-    let manifest = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
-        .expect("Cargo.toml is readable");
-    manifest
-        .split("[[bin]]")
-        .skip(1)
-        .map(|block| block.split("\n[").next().unwrap_or_default())
-        .find(|block| block.contains("name = \"ruchy\""))
-        .expect("Cargo.toml declares [[bin]] ruchy")
-        .to_string()
-}
-
-/// `minimal` is the core library only; the binary is a REPL-driven CLI, so it
-/// must say so instead of failing to compile under `--features minimal`.
-#[test]
-fn test_pmat_113_ruchy_binary_requires_the_repl_feature() {
-    let block = ruchy_bin_block();
-    let required = block
-        .lines()
-        .find(|line| line.trim_start().starts_with("required-features"))
-        .unwrap_or_default();
-    assert!(
-        required.contains("\"repl\""),
-        "[[bin]] ruchy must declare required-features = [\"repl\"]; found: {required:?}"
-    );
-}
-
-/// And the default build must still produce the binary.
-#[test]
-fn test_pmat_113_default_features_enable_repl() {
-    let manifest = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
-        .expect("Cargo.toml is readable");
-    let batteries = manifest
-        .lines()
-        .find(|line| line.starts_with("batteries-included ="))
-        .expect("batteries-included feature");
-    let default = manifest
-        .lines()
-        .find(|line| line.starts_with("default ="))
-        .expect("default feature");
-    assert!(default.contains("\"batteries-included\""), "{default}");
-    assert!(batteries.contains("\"repl\""), "{batteries}");
-}
-
 fn manifest() -> String {
-    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
-        .expect("Cargo.toml is readable")
+    fs::read_to_string(crate_path("Cargo.toml")).expect("Cargo.toml is readable")
 }
 
 /// Value of `key = ...` inside one manifest table, or empty.
@@ -246,7 +262,8 @@ fn toml_field(block: &str, key: &str) -> String {
         .unwrap_or_default()
 }
 
-/// `[[example]]` / `[[bench]]` tables as (name, required-features) pairs.
+/// `[[example]]` / `[[bench]]` / `[[test]]` / `[[bin]]` tables as
+/// (name, required-features) pairs.
 fn manifest_targets(manifest: &str, kind: &str) -> Vec<(String, String)> {
     manifest
         .split(&format!("[[{kind}]]"))
@@ -267,14 +284,59 @@ fn target_requires_repl(manifest: &str, kind: &str, stem: &str) -> bool {
         .any(|(name, required)| name.trim_matches('"') == stem && required.contains("\"repl\""))
 }
 
-fn repl_targets_without_required_features(manifest: &str, dir: &str, kind: &str) -> Vec<String> {
+fn repl_targets_without_required_features(
+    manifest: &str,
+    names: &[String],
+    dir: &str,
+    kind: &str,
+) -> Vec<String> {
     sources_in(dir)
         .iter()
-        .filter(|(_, src)| src.lines().any(line_references_repl))
-        .map(|(path, _)| path.file_stem().unwrap_or_default().to_string_lossy().into_owned())
+        .filter(|(_, src)| {
+            without_block_comments(src)
+                .lines()
+                .any(|line| line_references_repl(line, names))
+        })
+        .map(|(path, _)| stem_of(path))
         .filter(|stem| !target_requires_repl(manifest, kind, stem))
-        .map(|stem| format!("{dir}/{stem}.rs: add [[{kind}]] name = \"{stem}\" with required-features = [\"repl\"]"))
+        .map(|stem| {
+            format!("{dir}/{stem}.rs: add [[{kind}]] name = \"{stem}\" with required-features = [\"repl\"]")
+        })
         .collect()
+}
+
+/// A test target is gated either in source (`cfg`) or in the manifest
+/// (`[[test]]` with `required-features`).
+#[test]
+fn test_pmat_113_repl_tests_are_feature_gated() {
+    let names = repl_type_names();
+    let manifest = manifest();
+    let violations: Vec<String> = sources_in("tests")
+        .iter()
+        .filter(|(path, _)| !target_requires_repl(&manifest, "test", &stem_of(path)))
+        .flat_map(|(path, src)| ungated_repl_uses(path, src, &names))
+        .collect();
+    assert!(
+        violations.is_empty(),
+        "REPL-dependent tests must carry `{REPL_GATE}` (crate-level `#!` form or on the item) \
+         or a [[test]] required-features entry, so that `--no-default-features --features minimal` \
+         compiles:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn test_pmat_112_no_bare_assert_statements_in_tests() {
+    let violations: Vec<String> = sources_in("tests")
+        .iter()
+        .flat_map(|(path, src)| bare_assert_statements(path, src))
+        .collect();
+    assert!(
+        violations.is_empty(),
+        "bare `.assert();` statements discard a must_use value; wrap them in \
+         `support::assert_args_accepted(..)` or assert on the result:\n{}",
+        violations.join("\n")
+    );
 }
 
 /// Examples and benches cannot be cfg-gated (an empty crate has no `main`),
@@ -283,17 +345,145 @@ fn repl_targets_without_required_features(manifest: &str, dir: &str, kind: &str)
 #[test]
 fn test_pmat_113_repl_examples_and_benches_declare_required_features() {
     let manifest = manifest();
-    let mut violations = repl_targets_without_required_features(&manifest, "examples", "example");
+    let names = repl_type_names();
+    let mut violations =
+        repl_targets_without_required_features(&manifest, &names, "examples", "example");
     violations.extend(repl_targets_without_required_features(
-        &manifest, "benches", "bench",
+        &manifest, &names, "benches", "bench",
     ));
     assert!(violations.is_empty(), "{}", violations.join("\n"));
 }
 
+/// `minimal` is the core library only; the binary is a REPL-driven CLI, so it
+/// must say so instead of failing to compile under `--features minimal`.
+#[test]
+fn test_pmat_113_ruchy_binary_requires_the_repl_feature() {
+    assert!(
+        target_requires_repl(&manifest(), "bin", "ruchy"),
+        "[[bin]] ruchy must declare required-features = [\"repl\"]"
+    );
+}
+
+/// And the default build must still produce the binary.
+#[test]
+fn test_pmat_113_default_features_enable_repl() {
+    let manifest = manifest();
+    let batteries = manifest
+        .lines()
+        .find(|line| line.starts_with("batteries-included ="))
+        .expect("batteries-included feature");
+    let default = manifest
+        .lines()
+        .find(|line| line.starts_with("default ="))
+        .expect("default feature");
+    assert!(default.contains("\"batteries-included\""), "{default}");
+    assert!(batteries.contains("\"repl\""), "{batteries}");
+}
+
+#[test]
+fn test_pmat_113_repl_type_names_come_from_the_gated_module() {
+    let names = repl_type_names();
+    for expected in ["Repl", "ReplState", "ReplMode"] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "{expected} missing from {names:?}"
+        );
+    }
+    assert!(
+        !names.iter().any(|n| n == "ReplOutput"),
+        "wasm::ReplOutput must not count"
+    );
+}
+
+#[test]
+fn test_pmat_113_lint_discriminates_gated_from_ungated_repl_uses() {
+    let path = Path::new("x.rs");
+    let names = vec!["Repl".to_string(), "ReplState".to_string()];
+    let ungated = "use ruchy::runtime::Repl;\n#[test]\nfn t() {}\n";
+    assert_eq!(ungated_repl_uses(path, ungated, &names).len(), 1);
+    let file_gated = format!("#![cfg(feature = \"repl\")]\n{ungated}");
+    assert!(ungated_repl_uses(path, &file_gated, &names).is_empty());
+    let all_form = "#![cfg(all(not(target_arch = \"wasm32\"), feature = \"repl\"))]\nuse ruchy::runtime::Repl;\n";
+    assert!(ungated_repl_uses(path, all_form, &names).is_empty());
+    let body_use = "#[cfg(feature = \"repl\")]\n#[test]\nfn t() {\n    let a = 1;\n    let b = 2;\n    let c = 3;\n    let s = ReplState::new();\n}\n";
+    assert!(ungated_repl_uses(path, body_use, &names).is_empty());
+    let item_all_form =
+        "#[cfg(all(unix, feature = \"repl\"))]\n#[test]\nfn t() {\n    let r = Repl::new(d);\n}\n";
+    assert!(ungated_repl_uses(path, item_all_form, &names).is_empty());
+    let next_fn = "#[cfg(feature = \"repl\")]\n#[test]\nfn gated() {}\n\n#[test]\nfn open() {\n    let s = ReplState::new();\n}\n";
+    assert_eq!(ungated_repl_uses(path, next_fn, &names).len(), 1);
+    let top_level = "#[test]\nfn t() {}\n\nuse ruchy::runtime::Repl;\n";
+    assert_eq!(ungated_repl_uses(path, top_level, &names).len(), 1);
+}
+
+#[test]
+fn test_pmat_113_lint_sees_through_import_spellings_and_ignores_prose() {
+    let path = Path::new("x.rs");
+    let names = vec!["Repl".to_string(), "ReplState".to_string()];
+    let multi_line = "use ruchy::runtime::{\n    Repl,\n    Value,\n};\n";
+    assert_eq!(ungated_repl_uses(path, multi_line, &names).len(), 1);
+    let glob_then_use =
+        "use ruchy::runtime::*;\nfn t() {\n    let r = Repl::new(std::env::temp_dir());\n}\n";
+    assert_eq!(ungated_repl_uses(path, glob_then_use, &names).len(), 1);
+    let self_import =
+        "use ruchy::runtime::{self};\nfn t() {\n    runtime::repl::Repl::new(d);\n}\n";
+    assert_eq!(ungated_repl_uses(path, self_import, &names).len(), 1);
+    let prose = "// the runtime::Repl is not used here\nlet s = \"use ruchy::runtime::Repl;\";\nlet x = Replay::new();\nlet o: ReplOutput = WasmRepl::new();\n";
+    assert!(ungated_repl_uses(path, prose, &names).is_empty());
+    let block_comment =
+        "fn t() {\n    /*\n    let repl = Repl::new(d);\n    */\n    let live = Repl::new(d);\n}\n";
+    let hits = ungated_repl_uses(path, block_comment, &names);
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert!(hits[0].starts_with("x.rs:5:"), "{hits:?}");
+}
+
+#[test]
+fn test_pmat_112_lint_discriminates_bare_from_consumed_asserts() {
+    let bare = [
+        "fn t() {",
+        "    ruchy_cmd()",
+        "        .arg(\"x\")",
+        "        .assert(); // times out",
+        "}",
+    ];
+    assert!(is_bare_assert_statement(&bare, 3));
+    let spaced = ["fn t() {", "    ruchy_cmd().arg(\"x\").assert() ;", "}"];
+    assert!(is_bare_assert_statement(&spaced, 1));
+    let bound = [
+        "fn t() {",
+        "    let out = ruchy_cmd()",
+        "        .arg(\"x\")",
+        "        .assert();",
+        "}",
+    ];
+    assert!(!is_bare_assert_statement(&bound, 3));
+    let returned = [
+        "fn t() -> Assert {",
+        "    return ruchy_cmd()",
+        "        .assert();",
+        "}",
+    ];
+    assert!(!is_bare_assert_statement(&returned, 2));
+    let wrapped = [
+        "    assert_args_accepted(",
+        "        ruchy_cmd()",
+        "            .assert(),",
+        "    );",
+    ];
+    assert!(!is_bare_assert_statement(&wrapped, 2));
+    let mockito = [
+        "    let mock = server.mock(\"GET\", \"/\");",
+        "    mock.assert();",
+    ];
+    assert!(!is_bare_assert_statement(&mockito, 1));
+    let in_string = ["    let s = \"cmd.assert();\";"];
+    assert!(!is_bare_assert_statement(&in_string, 0));
+}
+
 #[test]
 fn test_pmat_113_manifest_target_parser_reads_name_and_required_features() {
-    let manifest = "[[example]]\nname = \"a\"\nrequired-features = [\"repl\"]\n\n[[example]]\nname = \"b\"\n\n[dependencies]\nx = \"1\"\n";
-    assert!(target_requires_repl(manifest, "example", "a"));
-    assert!(!target_requires_repl(manifest, "example", "b"));
+    let manifest = "[[test]]\nname = \"a\"\nrequired-features = [\"repl\"]\n\n[[test]]\nname = \"b\"\n\n[dependencies]\nx = \"1\"\n";
+    assert!(target_requires_repl(manifest, "test", "a"));
+    assert!(!target_requires_repl(manifest, "test", "b"));
     assert!(!target_requires_repl(manifest, "bench", "a"));
 }

--- a/tests/feature_gate_lint.rs
+++ b/tests/feature_gate_lint.rs
@@ -216,11 +216,11 @@ fn test_pmat_113_default_features_enable_repl() {
         .expect("Cargo.toml is readable");
     let batteries = manifest
         .lines()
-        .find(|line| line.starts_with("batteries-included"))
+        .find(|line| line.starts_with("batteries-included ="))
         .expect("batteries-included feature");
     let default = manifest
         .lines()
-        .find(|line| line.starts_with("default"))
+        .find(|line| line.starts_with("default ="))
         .expect("default feature");
     assert!(default.contains("\"batteries-included\""), "{default}");
     assert!(batteries.contains("\"repl\""), "{batteries}");

--- a/tests/feature_gate_lint.rs
+++ b/tests/feature_gate_lint.rs
@@ -13,9 +13,13 @@ const REPL_GATE: &str = "#[cfg(feature = \"repl\")]";
 const FILE_GATE_PREFIX: &str = "#![cfg(feature = ";
 
 fn test_sources() -> Vec<(PathBuf, String)> {
-    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    sources_in("tests")
+}
+
+fn sources_in(dir: &str) -> Vec<(PathBuf, String)> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(dir);
     let mut files: Vec<PathBuf> = fs::read_dir(&dir)
-        .expect("tests/ directory is readable")
+        .expect("source directory is readable")
         .flatten()
         .map(|entry| entry.path())
         .filter(|path| path.extension().is_some_and(|ext| ext == "rs"))
@@ -224,4 +228,72 @@ fn test_pmat_113_default_features_enable_repl() {
         .expect("default feature");
     assert!(default.contains("\"batteries-included\""), "{default}");
     assert!(batteries.contains("\"repl\""), "{batteries}");
+}
+
+fn manifest() -> String {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+        .expect("Cargo.toml is readable")
+}
+
+/// Value of `key = ...` inside one manifest table, or empty.
+fn toml_field(block: &str, key: &str) -> String {
+    block
+        .lines()
+        .filter_map(|line| line.trim_start().strip_prefix(key))
+        .filter_map(|rest| rest.trim_start().strip_prefix('='))
+        .map(|value| value.trim().to_string())
+        .next()
+        .unwrap_or_default()
+}
+
+/// `[[example]]` / `[[bench]]` tables as (name, required-features) pairs.
+fn manifest_targets(manifest: &str, kind: &str) -> Vec<(String, String)> {
+    manifest
+        .split(&format!("[[{kind}]]"))
+        .skip(1)
+        .map(|block| block.split("\n[").next().unwrap_or_default())
+        .map(|block| {
+            (
+                toml_field(block, "name"),
+                toml_field(block, "required-features"),
+            )
+        })
+        .collect()
+}
+
+fn target_requires_repl(manifest: &str, kind: &str, stem: &str) -> bool {
+    manifest_targets(manifest, kind)
+        .iter()
+        .any(|(name, required)| name.trim_matches('"') == stem && required.contains("\"repl\""))
+}
+
+fn repl_targets_without_required_features(manifest: &str, dir: &str, kind: &str) -> Vec<String> {
+    sources_in(dir)
+        .iter()
+        .filter(|(_, src)| src.lines().any(line_references_repl))
+        .map(|(path, _)| path.file_stem().unwrap_or_default().to_string_lossy().into_owned())
+        .filter(|stem| !target_requires_repl(manifest, kind, stem))
+        .map(|stem| format!("{dir}/{stem}.rs: add [[{kind}]] name = \"{stem}\" with required-features = [\"repl\"]"))
+        .collect()
+}
+
+/// Examples and benches cannot be cfg-gated (an empty crate has no `main`),
+/// so a REPL-dependent one must be declared with `required-features` and is
+/// then skipped, not broken, under `--features minimal`.
+#[test]
+fn test_pmat_113_repl_examples_and_benches_declare_required_features() {
+    let manifest = manifest();
+    let mut violations = repl_targets_without_required_features(&manifest, "examples", "example");
+    violations.extend(repl_targets_without_required_features(
+        &manifest, "benches", "bench",
+    ));
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}
+
+#[test]
+fn test_pmat_113_manifest_target_parser_reads_name_and_required_features() {
+    let manifest = "[[example]]\nname = \"a\"\nrequired-features = [\"repl\"]\n\n[[example]]\nname = \"b\"\n\n[dependencies]\nx = \"1\"\n";
+    assert!(target_requires_repl(manifest, "example", "a"));
+    assert!(!target_requires_repl(manifest, "example", "b"));
+    assert!(!target_requires_repl(manifest, "bench", "a"));
 }

--- a/tests/feature_gate_lint.rs
+++ b/tests/feature_gate_lint.rs
@@ -1,0 +1,133 @@
+#![allow(missing_docs)]
+//! Feature-gate lint for the integration test tree (PMAT-112, PMAT-113).
+//!
+//! The gate is `cargo check --tests --no-default-features --features minimal`
+//! together with `cargo clippy --all-targets --all-features -- -D warnings`.
+//! These tests are the fast discriminator: they name the offending file and
+//! line in milliseconds instead of after a full feature-matrix build.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const REPL_GATE: &str = "#[cfg(feature = \"repl\")]";
+const FILE_GATE_PREFIX: &str = "#![cfg(feature = ";
+
+fn test_sources() -> Vec<(PathBuf, String)> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
+        .expect("tests/ directory is readable")
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "rs"))
+        .collect();
+    files.sort();
+    files
+        .into_iter()
+        .map(|path| {
+            let src = fs::read_to_string(&path).expect("test source is readable");
+            (path, src)
+        })
+        .collect()
+}
+
+/// A line that pulls the REPL into the test target.
+fn line_references_repl(line: &str) -> bool {
+    line.contains("runtime::Repl")
+        || line.contains("runtime::repl")
+        || (line.contains("runtime::{") && line.contains("Repl"))
+}
+
+/// A crate-level `#![cfg(feature = "...")]` keeps the whole target out of
+/// the `minimal` build, whichever feature it names.
+fn has_file_level_feature_gate(src: &str) -> bool {
+    src.lines().any(|line| line.starts_with(FILE_GATE_PREFIX))
+}
+
+/// An item-level `#[cfg(feature = "repl")]` within the four lines above the
+/// use (attribute, `#[test]`, `fn` header, then the `use` inside the body).
+fn item_gated_above(lines: &[&str], idx: usize) -> bool {
+    let start = idx.saturating_sub(4);
+    lines[start..idx]
+        .iter()
+        .any(|line| line.trim() == REPL_GATE)
+}
+
+fn ungated_repl_uses(path: &Path, src: &str) -> Vec<String> {
+    if has_file_level_feature_gate(src) {
+        return Vec::new();
+    }
+    let lines: Vec<&str> = src.lines().collect();
+    lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line_references_repl(line))
+        .filter(|(idx, _)| !item_gated_above(&lines, *idx))
+        .map(|(idx, line)| format!("{}:{}: {}", path.display(), idx + 1, line.trim()))
+        .collect()
+}
+
+/// `....assert();` as a bare statement discards a `#[must_use]` value, which
+/// is a clippy error under `-D warnings` once the target's feature is on.
+fn is_bare_assert_statement(line: &str) -> bool {
+    let code = line.split("//").next().unwrap_or_default().trim();
+    code.ends_with(".assert();") && !code.contains("let ") && !code.contains('=')
+}
+
+fn bare_assert_statements(path: &Path, src: &str) -> Vec<String> {
+    src.lines()
+        .enumerate()
+        .filter(|(_, line)| is_bare_assert_statement(line))
+        .map(|(idx, line)| format!("{}:{}: {}", path.display(), idx + 1, line.trim()))
+        .collect()
+}
+
+#[test]
+fn test_pmat_113_repl_tests_are_feature_gated() {
+    let violations: Vec<String> = test_sources()
+        .iter()
+        .flat_map(|(path, src)| ungated_repl_uses(path, src))
+        .collect();
+    assert!(
+        violations.is_empty(),
+        "REPL-dependent tests must carry `{REPL_GATE}` (crate-level `#!` form or on the item) \
+         so that `--no-default-features --features minimal` compiles:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn test_pmat_112_no_bare_assert_statements_in_tests() {
+    let violations: Vec<String> = test_sources()
+        .iter()
+        .flat_map(|(path, src)| bare_assert_statements(path, src))
+        .collect();
+    assert!(
+        violations.is_empty(),
+        "bare `.assert();` statements discard a must_use value; wrap them in \
+         `support::assert_args_accepted(..)` or assert on the result:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn test_pmat_113_lint_discriminates_gated_from_ungated_repl_uses() {
+    let path = Path::new("x.rs");
+    let ungated = "use ruchy::runtime::Repl;\n#[test]\nfn t() {}\n";
+    assert_eq!(ungated_repl_uses(path, ungated).len(), 1);
+    let file_gated = format!("#![cfg(feature = \"repl\")]\n{ungated}");
+    assert!(ungated_repl_uses(path, &file_gated).is_empty());
+    let item_gated =
+        "#[cfg(feature = \"repl\")]\n#[test]\nfn t() {\n    use ruchy::runtime::repl::state::ReplState;\n}\n";
+    assert!(ungated_repl_uses(path, item_gated).is_empty());
+    let too_far = "#[cfg(feature = \"repl\")]\n\n\n\n\nuse ruchy::runtime::Repl;\n";
+    assert_eq!(ungated_repl_uses(path, too_far).len(), 1);
+}
+
+#[test]
+fn test_pmat_112_lint_discriminates_bare_from_consumed_asserts() {
+    assert!(is_bare_assert_statement("        .assert(); // times out"));
+    assert!(is_bare_assert_statement("    cmd.assert();"));
+    assert!(!is_bare_assert_statement("            .assert(),"));
+    assert!(!is_bare_assert_statement("    let out = cmd.assert();"));
+    assert!(!is_bare_assert_statement("        .assert()"));
+}

--- a/tests/issue_086_determinism_investigation.rs
+++ b/tests/issue_086_determinism_investigation.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![allow(missing_docs)]
 //! Investigation test for Issue #86: Non-deterministic state hashing
 //!

--- a/tests/issue_086_verify_fix.rs
+++ b/tests/issue_086_verify_fix.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![allow(missing_docs)]
 //! Verification test for Issue #86 fix: Run 100 iterations to verify determinism
 

--- a/tests/p0_book_005_performance_optimization.rs
+++ b/tests/p0_book_005_performance_optimization.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![allow(missing_docs)]
 //! P0-BOOK-005: Performance Optimization Test Suite
 //!

--- a/tests/p0_book_006_advanced_patterns.rs
+++ b/tests/p0_book_006_advanced_patterns.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![allow(missing_docs)]
 //! P0-BOOK-006: Advanced Patterns Test Suite
 //!

--- a/tests/parser_067_struct_pattern_test.rs
+++ b/tests/parser_067_struct_pattern_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![allow(missing_docs)]
 //! PARSER-067: Struct pattern matching tests
 //!

--- a/tests/probar_wasm_modules.rs
+++ b/tests/probar_wasm_modules.rs
@@ -361,6 +361,7 @@ fn test_probar_port_default_analyzer() {
 // REPL State Tests
 // =============================================================================
 
+#[cfg(feature = "repl")]
 #[test]
 fn test_probar_repl_state_new() {
     use ruchy::runtime::repl::state::ReplState;
@@ -373,6 +374,7 @@ fn test_probar_repl_state_new() {
     assert!(state.get_bindings().is_empty());
 }
 
+#[cfg(feature = "repl")]
 #[test]
 fn test_probar_repl_state_modes() {
     use ruchy::runtime::repl::state::{ReplMode, ReplState};
@@ -396,6 +398,7 @@ fn test_probar_repl_state_modes() {
     }
 }
 
+#[cfg(feature = "repl")]
 #[test]
 fn test_probar_repl_history() {
     use ruchy::runtime::repl::state::ReplState;
@@ -416,6 +419,7 @@ fn test_probar_repl_history() {
     assert_eq!(history[2], "cmd3");
 }
 
+#[cfg(feature = "repl")]
 #[test]
 fn test_probar_repl_bindings() {
     use ruchy::runtime::interpreter::Value;
@@ -435,6 +439,7 @@ fn test_probar_repl_bindings() {
     assert!(state.get_variable("z").is_none());
 }
 
+#[cfg(feature = "repl")]
 #[test]
 fn test_probar_repl_result_history() {
     use ruchy::runtime::interpreter::Value;
@@ -453,6 +458,7 @@ fn test_probar_repl_result_history() {
     assert_eq!(state.result_history_len(), 3);
 }
 
+#[cfg(feature = "repl")]
 #[test]
 fn test_probar_repl_peak_memory() {
     use ruchy::runtime::repl::state::ReplState;
@@ -473,6 +479,7 @@ fn test_probar_repl_peak_memory() {
     assert_eq!(state.get_peak_memory(), 2000);
 }
 
+#[cfg(feature = "repl")]
 #[test]
 fn test_probar_repl_snapshot_restore() {
     use ruchy::runtime::interpreter::Value;

--- a/tests/runtime_issue_148_struct_mut_self.rs
+++ b/tests/runtime_issue_148_struct_mut_self.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 /// RUNTIME-ISSUE-148: &mut self mutations don't persist in interpreter
 ///
 /// ROOT CAUSE: To be determined via Five Whys

--- a/tests/sqlite_004_runtime_anomalies.rs
+++ b/tests/sqlite_004_runtime_anomalies.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![allow(missing_docs)]
 #![allow(clippy::collapsible_match)]
 //! [SQLITE-TEST-004] Test Harness 1.4: Runtime Anomaly Validation Suite

--- a/tests/string_interpolation_repl_fix.rs
+++ b/tests/string_interpolation_repl_fix.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "repl")]
 #![allow(missing_docs)]
 //! String Interpolation REPL Bug Fix Test
 //! EXTREME TDD: RED phase - This test MUST fail before the fix


### PR DESCRIPTION
## Summary

Stage 2 (features) of the pre-release gate was red on two feature sets CI never compiles. This PR makes both green and adds the fast discriminator that keeps them green.

- **minimal**: eleven test targets, eight examples, three benches and the ruchy binary itself import `ruchy::runtime::repl` unconditionally. Ten test files get a crate-level `#![cfg(feature = "repl")]`, seven REPL-state tests in `probar_wasm_modules` get item-level gates, and the examples, benches and the `[[bin]]` declare `required-features = ["repl"]` (`minimal` is declared as the core library only; `default` still enables `repl` through `batteries-included`, so `cargo install ruchy` is unchanged).
- **all-features**: four discarded `must_use` `Assert` values in `tests/cli_contract_notebook.rs` (a target compiled only with the notebook feature) now go through `support::assert_args_accepted`, as the other CLI contract tests do since PMAT-104.
- `tests/feature_gate_lint.rs`: statement-aware bare-assert scan, REPL-import gate scan for tests (whole-word identifiers declared under src/runtime/repl, comments and strings stripped), required-features scan for examples/benches, manifest checks for the binary. `contracts/test-feature-gates-v1.yaml` binds them (pv validate/lint clean).

## Measured

```
cargo clippy --all-targets --no-default-features --features minimal -- -D warnings   # clean (was: 5 errors in bin, 1 in example test_mutation, 11 test targets)
cargo check -p ruchy --bin ruchy                                                   # default features still build the binary
cargo clippy --test cli_contract_notebook --test probar_wasm_modules --features notebook -- -D warnings   # clean
cargo test --test feature_gate_lint                                                # 10 passed
```

DoD mutations: dropping one crate-level gate fails the lint and the minimal build on that target; dropping the bin's required-features fails the lint; the pre-fix manifest fails the examples/benches lint with 11 violations.

Tickets: PMAT-113 (minimal feature set), PMAT-112 (all-features must_use). Plan: docs/specifications/ruchy-5.0.0-beta.2-release-plan.md §2 Z5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Quorum review (3 agy lanes, review-only)

Consensus: `required-features` on the binary is the right semantics and breaks no documented workflow; nothing drops from the default test run. All three lanes found the first lint unsound (comment and `return cmd.assert();` false positives; glob and multi-line import false negatives); folded in by the hardening commit. The one do-not-implement verdict rested on a two-dot diff artifact (phantom deletions), refuted by `git diff --name-status origin/main...HEAD` (2 added, 13 modified, 0 deleted).
