### PR TITLE
release: 5.0.0-beta.2 — version bump, ruchy-wasm dependency, CHANGELOG [PMAT-100]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,87 @@ All notable changes to the Ruchy programming language will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0-beta.2] - 2026-09-05
+
+First 5.0 release published to crates.io. `5.0.0-beta.1` (2026-04-04, below) was
+versioned in this repository but never tagged or published; crates.io stayed at
+`4.2.1`. Release plan and evidence:
+`docs/specifications/ruchy-5.0.0-beta.2-release-plan.md`,
+`docs/specifications/evidence/2026-09-05-release-gather/`.
+
+### Breaking (against 4.2.1, the last published crate)
+- Seven words are reserved and no longer valid identifiers: `requires`, `ensures`,
+  `invariant`, `decreases`, `infra`, `signal`, `yield`. A 4.2.1 program that uses
+  any of them as a variable, parameter or field fails `ruchy check`. Migrate with
+  `ruchy migrate-4to5 <path>` (dry-run by default; renames colliding identifiers).
+  Measured over 1286 corpus files: 2 regressions, both keyword collisions
+  (`evidence/…/differential-check-summary.txt`).
+- Minimum supported Rust version is 1.91 (was 1.85), following the aprender
+  monorepo facades (#207).
+- The `ruchy` binary declares `required-features = ["repl"]`; `--no-default-features
+  --features minimal` builds the core library only. Default features are unchanged,
+  so `cargo install ruchy` still builds the binary (#212).
+
+### Added
+- `ruchy tier <path>`: §14.2 tier distribution reporter with per-file breakdown,
+  JSON and markdown output, baselines and regression gate, per-file parse timeout,
+  TOML config, `--exclude`, and CI gates `--fail-under`, `--fail-under-f1`,
+  `--fail-on-totality-violation`, `--fail-exempt-density-above`,
+  `--fail-diff-exempt-density-above`, `--fail-pub-bronze-above`,
+  `--fail-on-scorecard` ([PROVABILITY-001]…[PROVABILITY-023], [PROVABILITY-034],
+  [PROVABILITY-035], [TIER-001], [TIER-002]).
+- `ruchy contracts check|list|sync` and `ruchy suggest-contracts` wired to the real
+  contract scanner, with `--pub-only` and markdown output ([PROVABILITY-024]…
+  [PROVABILITY-026], [PROVABILITY-030], [PROVABILITY-031]).
+- §14.10 runtime skeletons for the provability pillar ([SPEC-HARDREQ-002]).
+- Parser accepts `#[attribute]` syntax per 5.0 spec §3 ([PARSER-ATTR-001]).
+- Release engineering: package `include` allowlist and hygiene tests (#202); a
+  `release.yml` publish job that can only go green by publishing — builds first,
+  `CARGO_REGISTRY_TOKEN`, index poll between `ruchy` and `ruchy-wasm`, pre-release
+  derived from the tag (#205); the pre-release gate v2 with eight measured stages
+  and a go/no-go receipt (`make pre-release-gate`, #213); dispatch totality and
+  determinism contracts for `transpile`/`eval` (#211); feature-gate lint for the
+  test tree (#212); manifest lints for clean-room, MSRV and version coherence
+  (#207, this release).
+
+### Changed
+- Dependencies come from the aprender monorepo on crates.io (`aprender-compute`,
+  `aprender-core`, `aprender-train`, `aprender-viz`, `aprender-simulate` 0.65);
+  nothing is pulled from sibling checkouts, so the crate builds from a clean
+  `CARGO_HOME` (#207). Numeric results of the PCA and matmul paths follow
+  aprender-core 0.65 (f64 accumulation, two-pass variance).
+- `dataframe` feature ported to polars-core 0.55; CSV support comes from
+  `polars-io` directly instead of polars' `csv` meta-feature (#208).
+- One roadmap: `docs/roadmaps/roadmap.yaml`; the two frozen copies live under
+  `docs/archive/` and a test enforces the single source (#206).
+- `ruchy compile` honours `CARGO_TARGET_DIR` ([COMPILER-001]).
+- `examples/24_math_science.ruchy` migrated (`signal` → `signal_val`); all 155
+  examples must `ruchy check` (#203).
+
+### Fixed
+- Parser infinite loops on an unclosed actor body and on the `handler` keyword
+  ([PARSER-ACTOR-HANG], [PARSER-ACTOR-HANG-2]).
+- `ruchy prove` no longer loops on EOF; the `ruchy` binary's own unit-test target
+  runs to completion (mcp stub, prover input, watch mode) (#204).
+- The `AllImplemented` contract-binding check in `build.rs` looked two directories
+  up and never ran (#204).
+- A clean checkout could not build: `generated_contracts.rs` is tracked (#200).
+- Identifier property tests carry the full reserved-word blocklist (#196, #210).
+- Self-admitted technical debt in `src/` is zero; placeholders became tickets (#209).
+- Clippy on Rust 1.98: `must_use` `Assert` values in CLI contract tests, six
+  functions over the complexity limit (#204, #212).
+
+### Removed
+- Quarantine directories and colon-named files that broke `cargo package` on
+  Windows and inflated the crate (#202).
+
+### Security
+- All RUSTSEC advisories cleared: `h2` 0.4.19, patched `wasmtime` 47.x,
+  `chacha20` 0.10.2 (unyanked), `quick-xml` and `object_store` no longer in the
+  dependency graph (#199, #204, #207, #208). `cargo audit` is a mandatory stage of
+  the release gate.
+
+
 ## [5.0.0-beta.1] - 2026-04-04
 
 ### Sovereign Platform: Beta Progression

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "ruchy"
-version = "5.0.0-beta.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "alimentar",
  "anyhow",
@@ -6826,7 +6826,7 @@ dependencies = [
 
 [[package]]
 name = "ruchy-wasm"
-version = "5.0.0-beta.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ assertions_on_constants = "allow"  # Tests assert expected constants
 overly_complex_bool_expr = "allow"  # Tests can have complex conditions
 
 [workspace.package]
-version = "5.0.0-beta.1"
+version = "5.0.0-beta.2"
 edition = "2021"
 authors = ["Noah Gift"]
 license = "MIT OR Apache-2.0"

--- a/ruchy-wasm/Cargo.toml
+++ b/ruchy-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruchy-wasm"
-version = "5.0.0-beta.1"
+version = "5.0.0-beta.2"
 edition = "2021"
 authors = ["Noah Gift"]
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["wasm", "compilers", "web-programming"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ruchy = { version = "5.0.0-alpha.1", path = "..", default-features = false, features = ["wasm-compile"] }
+ruchy = { version = "5.0.0-beta.2", path = "..", default-features = false, features = ["wasm-compile"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/tests/release_manifest_lint.rs
+++ b/tests/release_manifest_lint.rs
@@ -214,3 +214,56 @@ fn test_pmat_094_lockfile_has_no_yanked_chacha20() {
         "Cargo.lock has no chacha20 package block; the test would be vacuous"
     );
 }
+
+/// First `key = "value"` at column 0 (the `[package]` field), or empty.
+fn top_level_string(manifest: &str, key: &str) -> String {
+    manifest
+        .lines()
+        .filter_map(|line| line.strip_prefix(key))
+        .filter_map(|rest| rest.trim_start().strip_prefix('='))
+        .map(|rest| rest.trim().trim_matches('"').to_string())
+        .next()
+        .unwrap_or_default()
+}
+
+/// `version = "…"` inside the inline table of `dep = { … }`, or empty.
+fn inline_dependency_version(manifest: &str, dep: &str) -> String {
+    manifest
+        .lines()
+        .filter(|line| line.starts_with(&format!("{dep} = {{")))
+        .filter_map(|line| line.split("version = \"").nth(1))
+        .filter_map(|rest| rest.split('"').next())
+        .map(str::to_string)
+        .next()
+        .unwrap_or_default()
+}
+
+/// PMAT-100: `ruchy-wasm` is published right after `ruchy` and must depend on
+/// the version being published; the two crates carry one version number.
+#[test]
+fn test_pmat_100_ruchy_wasm_tracks_the_workspace_version() {
+    let root = read(&manifest_dir().join("Cargo.toml"));
+    let wasm = read(&manifest_dir().join("ruchy-wasm/Cargo.toml"));
+    let version = top_level_string(&root, "version");
+    assert!(!version.is_empty(), "root [package] version missing");
+    assert_eq!(
+        top_level_string(&wasm, "version"),
+        version,
+        "ruchy-wasm version"
+    );
+    assert_eq!(
+        inline_dependency_version(&wasm, "ruchy"),
+        version,
+        "ruchy-wasm must depend on the ruchy version being published"
+    );
+}
+
+#[test]
+fn test_pmat_100_manifest_readers_read_package_and_inline_versions() {
+    let root =
+        "[package]\nname = \"x\"\nversion = \"1.2.3\"\n\n[dependencies]\nversion-sort = \"0.1\"\n";
+    assert_eq!(top_level_string(root, "version"), "1.2.3");
+    let wasm = "ruchy = { version = \"1.2.3\", path = \"..\", default-features = false }\n";
+    assert_eq!(inline_dependency_version(wasm, "ruchy"), "1.2.3");
+    assert_eq!(inline_dependency_version(wasm, "other"), "");
+}


### PR DESCRIPTION
## Summary

Terminal ticket of the 5.0.0-beta.2 release plan (§2 Z9, §5 steps 3-4).

- Version 5.0.0-beta.2 in `Cargo.toml` and `ruchy-wasm/Cargo.toml`; ruchy-wasm now depends on `ruchy = "5.0.0-beta.2"` (it said `5.0.0-alpha.1`), so the second publish step of `release.yml` resolves the crate that was just published. Lockfile refreshed with `cargo update -w`; `cargo metadata --locked` clean.
- `CHANGELOG.md`: `[5.0.0-beta.2]` written from the merged PRs (#199-#213) and the commit history since the never-published beta.1: Breaking (seven reserved words, MSRV 1.91, binary requires `repl`), Added, Changed, Fixed, Removed, Security.
- `tests/release_manifest_lint.rs`: the two crates carry one version and ruchy-wasm depends on it. RED on the old manifests, GREEN now.

**Do not merge before the pre-release gate receipt says `go`** (plan §5 step 2; the receipt lands in the plan v3 PR). After merge: `git tag -a v5.0.0-beta.2 && git push origin v5.0.0-beta.2` drives `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
