### PR TITLE
fix(release): never package proptest regression artifacts; clean-room packages from a detached worktree of HEAD [PMAT-127]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,7 @@ include = [
     "static/notebook.html",
     "golden_traces/**",
     "notebooks/**",
+    "!**/*.proptest-regressions",
 ]
 
 autobins = false

--- a/scripts/pre-release-gate.sh
+++ b/scripts/pre-release-gate.sh
@@ -35,6 +35,7 @@ GOLDEN_DIR="$ROOT/tests/golden"
 EVIDENCE_DIR="$ROOT/docs/specifications/evidence/$(date +%Y-%m-%d)-dogfood"
 RECEIPT="$EVIDENCE_DIR/receipt.json"
 TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/target}"
+PKGTREE=""   # detached worktree of HEAD used by clean_room + package (PMAT-127)
 
 if [ "${1:-}" = "--worker-diff" ]; then
     WORK=""
@@ -638,8 +639,14 @@ stage_clean_room() {
         return 0
     fi
 
-    say "  cargo package -p ruchy (with verification build) ..."
-    (cd "$ROOT" && command cargo package -p ruchy) > "$WORK/package.log" 2>&1
+    # Package from a detached worktree of HEAD: the packaged set is exactly what a fresh
+    # clone (and the release workflow) sees, and gitignored artifacts of local test runs
+    # (*.proptest-regressions, PMAT-127) cannot trip cargo's dirty check. tree_dirt above
+    # still guarantees HEAD == working tree for tracked files; --allow-dirty is never used.
+    PKGTREE="$WORK/pkgtree"
+    say "  cargo package -p ruchy from a detached worktree of HEAD (with verification build) ..."
+    (cd "$ROOT" && git worktree add --detach --quiet "$PKGTREE" HEAD) > "$WORK/package.log" 2>&1 \
+        && (cd "$PKGTREE" && command cargo package -p ruchy --target-dir "$TARGET_DIR") >> "$WORK/package.log" 2>&1
     local pkg_exit=$?
     if [ "$pkg_exit" -ne 0 ]; then
         tail -25 "$WORK/package.log"
@@ -653,10 +660,12 @@ stage_clean_room() {
             > "$STAGES/package.json"
         report clean_room FAIL "cargo package -p ruchy exit=$pkg_exit"
         report package FAIL "cargo package -p ruchy exit=$pkg_exit"
+        (cd "$ROOT" && git worktree remove --force "$PKGTREE") > /dev/null 2>&1 || true
         return 0
     fi
 
     stage_package "$version"
+    (cd "$ROOT" && git worktree remove --force "$PKGTREE") > /dev/null 2>&1 || true
 
     local crate="$TARGET_DIR/package/ruchy-$version.crate"
     local ex="$WORK/cleanroom"
@@ -733,7 +742,7 @@ stage_package() {
     local version="$1"
     local crate="$TARGET_DIR/package/ruchy-$version.crate"
     local listing="$WORK/pkg-list.txt"
-    (cd "$ROOT" && command cargo package --list -p ruchy) > "$listing" 2> "$WORK/pkg-list.err"
+    (cd "${PKGTREE:-$ROOT}" && command cargo package --list -p ruchy --target-dir "$TARGET_DIR") > "$listing" 2> "$WORK/pkg-list.err"
     local list_exit=$?
     if [ "$list_exit" -ne 0 ] || [ ! -f "$crate" ]; then
         tail -10 "$WORK/pkg-list.err"

--- a/tests/release_hygiene.rs
+++ b/tests/release_hygiene.rs
@@ -145,3 +145,28 @@ fn test_pmat_092_cargo_lock_present_in_package_list() {
         "Cargo.lock must be present in the packaged file list"
     );
 }
+
+/// PMAT-127: proptest writes `*.proptest-regressions` files next to failing
+/// property tests. They are gitignored, five old ones are tracked, and
+/// `tests/**` would ship all of them; the allowlist must negate them so the
+/// crate never carries test-run artifacts.
+#[test]
+fn test_pmat_127_include_negates_proptest_regressions() {
+    let cargo_toml = std::fs::read_to_string("Cargo.toml").expect("failed to read Cargo.toml");
+    let value: toml::Table = cargo_toml
+        .parse::<toml::Table>()
+        .expect("failed to parse Cargo.toml");
+    let include = value
+        .get("package")
+        .and_then(|p| p.get("include"))
+        .and_then(|i| i.as_array())
+        .expect("[package] include allowlist");
+    let negates = include
+        .iter()
+        .filter_map(|v| v.as_str())
+        .any(|pattern| pattern == "!**/*.proptest-regressions");
+    assert!(
+        negates,
+        "[package] include must contain \"!**/*.proptest-regressions\"; got {include:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Gate run 3 on `main` (plan §5 step 2) reached the clean-room stage on a clean tree and `cargo package -p ruchy` exited 101: 24 gitignored `tests/*.proptest-regressions` artifacts from earlier property-test runs match the `tests/**` include, and cargo 1.98 reports included-or-not untracked files as uncommitted even when git ignores them. A fresh clone never has them, so the release workflow was never at risk; the gate's local clean room was.

- `Cargo.toml`: include gains `!**/*.proptest-regressions`. Five tracked artifacts leave the crate (`cargo package --list`: 0 such files in 1446).
- `scripts/pre-release-gate.sh`: stage 5 packages and lists from `git worktree add --detach HEAD`, so the packaged set is exactly what a fresh clone sees. The dirty-tree precheck is unchanged; `--allow-dirty` is still never used; the worktree is removed after the package stage on both paths.
- `tests/release_hygiene.rs`: the allowlist must carry the negation (RED on the old manifest).

## Measured

- `./scripts/pre-release-gate.sh --only clean_room,package` on this branch with an ignored `tests/stdlib_process.proptest-regressions` present: package PASS (files=1446, colon_paths=0, has_lock=true); clean_room result attached in the plan v3 PR.
- DoD mutation: the previous script on the same tree is the measured run-3 failure (exit 101).
- bashrs on the script: 13 errors, identical to `main` (SC1087 on jq filter strings, DET002, SEC010); tracked as PMAT-128, not introduced here.

Pmat-Ticket: PMAT-127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
