### PR TITLE
fix(wasm): root crate builds for wasm32; release.yml and the gate select the getrandom wasm_js backend [PMAT-129][PMAT-130]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
       - name: Build WASM package
+        env:
+          # getrandom 0.3 (rand 0.9 via aprender-core) needs the wasm_js backend on wasm32 (PMAT-129)
+          RUSTFLAGS: --cfg getrandom_backend="wasm_js"
         run: wasm-pack build --target web --no-default-features --features wasm-compile
         timeout-minutes: 10
       - name: Extract version from tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6756,6 +6756,7 @@ dependencies = [
  "criterion",
  "forjar",
  "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "glob",
  "html5ever",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,11 +389,13 @@ signal-hook = "0.3"  # Graceful shutdown handling
 # WASM-specific dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+getrandom03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }  # rand 0.9 via aprender-core (PMAT-129); needs --cfg getrandom_backend="wasm_js" too
+serde-wasm-bindgen = "0.6"  # used by src/wasm_bindings.rs; was a dev-dependency only (PMAT-129)
 js-sys = "0.3"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"
-web-sys = "0.3"
+web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "HtmlCanvasElement"] }
 # WASM-compatible tokio without networking
 tokio = { version = "1.47", features = ["macros", "rt", "time"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,7 +395,7 @@ js-sys = "0.3"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"
-web-sys = { version = "0.3", features = ["CanvasRenderingContext2d", "HtmlCanvasElement"] }
+web-sys = { version = "0.3", features = ["CanvasRenderingContext2d"] }
 # WASM-compatible tokio without networking
 tokio = { version = "1.47", features = ["macros", "rt", "time"], optional = true }
 

--- a/Makefile
+++ b/Makefile
@@ -1729,7 +1729,7 @@ e2e-install-deps:
 # Build WASM module for browser (with minimal features - no tokio)
 wasm-build:
 	@echo "🔨 Building WASM module..."
-	wasm-pack build --target web --out-dir pkg -- --no-default-features --features wasm-compile
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build --target web --out-dir pkg -- --no-default-features --features wasm-compile
 	@echo "✅ WASM module built: pkg/ruchy_bg.wasm"
 
 wasm-deploy: wasm-build

--- a/ruchy-wasm/README.md
+++ b/ruchy-wasm/README.md
@@ -24,6 +24,8 @@ npm install ruchy-wasm
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 # Build the WASM package
+# getrandom 0.3 (pulled in through aprender-core) needs the wasm_js backend on wasm32:
+export RUSTFLAGS='--cfg getrandom_backend="wasm_js"'
 wasm-pack build --target web
 
 # For bundler environments (webpack, vite, etc.)

--- a/scripts/pre-release-gate.sh
+++ b/scripts/pre-release-gate.sh
@@ -7,7 +7,7 @@
 #
 # Stages, in order:
 #   1 tests        cargo test --lib -p ruchy
-#   2 features     clippy x3 feature sets + fmt (CI toolchain) + cargo audit
+#   2 features     clippy x3 feature sets + wasm32 build + fmt (CI toolchain) + cargo audit
 #   3 verbs        verb surface derived from the BUILT binary, each run on tests/golden/
 #   4 differential three-way vs the 4.2.1 baseline over examples/ + sibling corpora
 #   5 clean_room   cargo package -> extract -> --locked and unlocked builds, fresh CARGO_HOME
@@ -213,12 +213,32 @@ clippy_run() {
 }
 
 stage_features() {
-    hdr "STAGE 2/8  features -- clippy x3, fmt, audit"
-    local d a m fmt_exit audit_exit
+    hdr "STAGE 2/8  features -- clippy x3, wasm32 build, fmt, audit"
+    local d a m w fmt_exit audit_exit
 
     clippy_run default; d=$?
     clippy_run all --all-features; a=$?
     clippy_run minimal --no-default-features --features minimal; m=$?
+
+    # wasm32: the release workflow's Build WASM job (PMAT-129/130). getrandom 0.3 (via
+    # aprender-core's rand 0.9) needs the wasm_js backend both as a feature (Cargo.toml,
+    # wasm32 table) and as a cfg flag; the flag is set here exactly as release.yml sets it.
+    if ! rustup target list --installed 2> /dev/null | grep -qx 'wasm32-unknown-unknown'; then
+        say "  installing the wasm32-unknown-unknown target ..."
+        rustup target add wasm32-unknown-unknown > "$WORK/wasm32-target.log" 2>&1 || true
+    fi
+    if rustup target list --installed 2> /dev/null | grep -qx 'wasm32-unknown-unknown'; then
+        say "  build (wasm32-unknown-unknown, --no-default-features --features wasm-compile) ..."
+        (cd "$ROOT" && RUSTFLAGS='--cfg getrandom_backend="wasm_js"' command cargo build --lib \
+            --target wasm32-unknown-unknown --no-default-features --features wasm-compile) \
+            > "$WORK/wasm32.log" 2>&1
+        w=$?
+        [ "$w" -eq 0 ] || tail -20 "$WORK/wasm32.log"
+        say "  wasm32 exit=$w"
+    else
+        w=127
+        say "  wasm32-unknown-unknown target unavailable -- the wasm build FAILS the stage (never skipped silently)"
+    fi
 
     if rustup run "$CI_TOOLCHAIN" cargo --version > /dev/null 2>&1; then
         (cd "$ROOT" && command cargo "+$CI_TOOLCHAIN" fmt --all -- --check) > "$WORK/fmt.log" 2>&1
@@ -243,14 +263,14 @@ stage_features() {
     fi
 
     local status="PASS"
-    if [ "$d" -ne 0 ] || [ "$a" -ne 0 ] || [ "$m" -ne 0 ] || [ "$fmt_exit" -ne 0 ] || [ "$audit_exit" -ne 0 ]; then
+    if [ "$d" -ne 0 ] || [ "$a" -ne 0 ] || [ "$m" -ne 0 ] || [ "$w" -ne 0 ] || [ "$fmt_exit" -ne 0 ] || [ "$audit_exit" -ne 0 ]; then
         status="FAIL"
     fi
-    jq -n --arg s "$status" --argjson d "$d" --argjson a "$a" --argjson m "$m" \
+    jq -n --arg s "$status" --argjson d "$d" --argjson a "$a" --argjson m "$m" --argjson w "$w" \
         --argjson f "$fmt_exit" --argjson au "$audit_exit" \
-        '{status: $s, default: $d, all: $a, minimal: $m, fmt: $f, audit: $au}' \
+        '{status: $s, default: $d, all: $a, minimal: $m, wasm32: $w, fmt: $f, audit: $au}' \
         > "$STAGES/features.json"
-    report features "$status" "default=$d all=$a minimal=$m fmt=$fmt_exit audit=$audit_exit"
+    report features "$status" "default=$d all=$a minimal=$m wasm32=$w fmt=$fmt_exit audit=$audit_exit"
 }
 
 # --------------------------------------------------------------------------------------

--- a/src/computebrick/canvas.rs
+++ b/src/computebrick/canvas.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 
 /// RGBA color with f32 components (0.0-1.0).
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Color {
     pub r: f32,
     pub g: f32,
@@ -86,7 +86,7 @@ impl Point {
 }
 
 /// Rectangle with position and size.
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Rect {
     pub x: f32,
     pub y: f32,

--- a/src/computebrick/mod.rs
+++ b/src/computebrick/mod.rs
@@ -118,7 +118,7 @@ pub enum MouseButton {
 }
 
 /// Widget specification for serialization.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WidgetSpec {
     pub kind: WidgetKind,
     pub bounds: Option<Rect>,
@@ -126,7 +126,7 @@ pub struct WidgetSpec {
 }
 
 /// Widget types.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum WidgetKind {
     BrailleGraph {
         data: Vec<f64>,
@@ -159,7 +159,7 @@ pub enum WidgetKind {
 }
 
 /// Graph rendering modes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum GraphMode {
     /// Braille patterns (2x4 dots per cell) - highest resolution.
     #[default]
@@ -171,7 +171,7 @@ pub enum GraphMode {
 }
 
 /// Widget styling options.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct WidgetStyle {
     pub color: Option<Color>,
     pub background: Option<Color>,
@@ -180,7 +180,7 @@ pub struct WidgetStyle {
 }
 
 /// Border styles for panels.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum BorderStyle {
     /// No border.
     #[default]

--- a/src/computebrick/wasm_entry.rs
+++ b/src/computebrick/wasm_entry.rs
@@ -133,14 +133,8 @@ pub fn create_widget_from_json(json: &str) -> Result<WasmWidget, JsValue> {
     })
 }
 
-/// Initialize WASM module.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(start)]
-pub fn wasm_init() {
-    // Set panic hook for better error messages
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::set_once();
-}
+// The module start hook lives in src/wasm_bindings.rs (`wasm_init`); a second
+// `#[wasm_bindgen(start)]` here exported the same symbol twice (PMAT-129).
 
 // Non-WASM stubs for testing
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/computebrick/wasm_entry.rs
+++ b/src/computebrick/wasm_entry.rs
@@ -57,8 +57,6 @@ impl WasmWidget {
     /// Render to a Canvas2D context.
     #[wasm_bindgen]
     pub fn render_to_canvas(&mut self, ctx: &CanvasRenderingContext2d, width: u32, height: u32) {
-        use super::canvas::Canvas;
-
         // Resize buffer if needed
         let char_width = 8.0;
         let char_height = 16.0;
@@ -99,8 +97,6 @@ impl WasmWidget {
     /// Get widget as string (for terminal/text output).
     #[wasm_bindgen]
     pub fn to_string(&mut self) -> String {
-        use super::canvas::Canvas;
-
         self.buffer.clear();
         self.inner.layout(self.buffer.bounds());
         self.inner.paint(&mut self.buffer);
@@ -162,8 +158,6 @@ impl WasmWidget {
     }
 
     pub fn to_string(&mut self) -> String {
-        use super::canvas::Canvas;
-
         self.buffer.clear();
         self.inner.layout(self.buffer.bounds());
         self.inner.paint(&mut self.buffer);

--- a/src/computebrick/wasm_entry.rs
+++ b/src/computebrick/wasm_entry.rs
@@ -6,12 +6,12 @@
 use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
-use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
+use web_sys::CanvasRenderingContext2d;
 
 use super::api;
-use super::canvas::{CellBuffer, Color, Rect};
+use super::canvas::CellBuffer;
 use super::widgets::Brick;
-use super::{GraphMode, WidgetKind, WidgetSpec};
+use super::WidgetSpec;
 
 /// WASM-compatible widget container.
 #[cfg(target_arch = "wasm32")]

--- a/src/wasm_bindings.rs
+++ b/src/wasm_bindings.rs
@@ -44,7 +44,7 @@ impl RuchyWasm {
     /// let result = compile("example");
     /// assert_eq!(result, Ok(()));
     /// ```
-    pub fn compile(&self, source: &str) -> Result<String, JsValue> {
+    pub fn compile(&mut self, source: &str) -> Result<String, JsValue> {
         let mut parser = Parser::new(source);
         let ast = parser
             .parse()
@@ -86,7 +86,7 @@ impl RuchyWasm {
     /// This method enables non-blocking compilation in web browsers
     #[wasm_bindgen]
     pub fn compile_async(&self, source: String) -> Promise {
-        let transpiler = self.transpiler.clone();
+        let mut transpiler = self.transpiler.clone();
         future_to_promise(async move {
             // Parse and transpile in async context
             let mut parser = Parser::new(&source);
@@ -104,7 +104,7 @@ impl RuchyWasm {
     /// Each cell compiles independently for maximum parallelism
     #[wasm_bindgen]
     pub fn compile_cells_parallel(&self, sources: &js_sys::Array) -> Promise {
-        let transpiler = self.transpiler.clone();
+        let mut transpiler = self.transpiler.clone();
         let sources: Vec<String> = sources
             .iter()
             .map(|val| val.as_string().unwrap_or_default())
@@ -173,7 +173,7 @@ impl RuchyWasm {
     /// Execute cell with performance monitoring (WASM-007)
     /// Target: <10ms execution time for typical cells
     #[wasm_bindgen]
-    pub fn execute_cell_fast(&self, source: &str) -> JsValue {
+    pub fn execute_cell_fast(&mut self, source: &str) -> JsValue {
         let start_time = js_sys::Date::now();
 
         // Fast path compilation
@@ -212,7 +212,7 @@ impl RuchyWasm {
 
     /// Benchmark cell execution performance
     #[wasm_bindgen]
-    pub fn benchmark_cell_execution(&self, iterations: usize) -> JsValue {
+    pub fn benchmark_cell_execution(&mut self, iterations: usize) -> JsValue {
         let test_cases = vec![
             "let x = 42",                          // Simple assignment
             "let y = x * 2 + 1",                   // Expression
@@ -300,7 +300,7 @@ impl WebWorkerRuntime {
             let start_time = js_sys::Date::now();
 
             // Create compiler instance for this worker
-            let compiler = RuchyWasm::new();
+            let mut compiler = RuchyWasm::new();
             let result = compiler.compile(&task_data);
 
             let end_time = js_sys::Date::now();

--- a/tests/fixtures/dogfood-receipt-example.json
+++ b/tests/fixtures/dogfood-receipt-example.json
@@ -4,8 +4,19 @@
   "head": "be1b1574ab0d0f2b5b7c1c1e1f0a9f3d2c4b6a80",
   "baseline": "4.2.1",
   "stages": {
-    "tests": { "status": "PASS", "exit": 0 },
-    "features": { "status": "PASS", "default": 0, "all": 0, "minimal": 0, "fmt": 0, "audit": 0 },
+    "tests": {
+      "status": "PASS",
+      "exit": 0
+    },
+    "features": {
+      "status": "PASS",
+      "default": 0,
+      "all": 0,
+      "minimal": 0,
+      "wasm32": 0,
+      "fmt": 0,
+      "audit": 0
+    },
     "verbs": {
       "status": "PASS",
       "total": 47,
@@ -13,8 +24,22 @@
       "warn": 16,
       "fail": 0,
       "list": [
-        { "verb": "check", "mode": "golden", "input": "tests/golden/hello.ruchy", "exit": 0, "stdout_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "status": "PASS" },
-        { "verb": "repl", "mode": "help_only", "exit": 0, "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "status": "WARN", "reason": "needs a TTY" }
+        {
+          "verb": "check",
+          "mode": "golden",
+          "input": "tests/golden/hello.ruchy",
+          "exit": 0,
+          "stdout_sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          "status": "PASS"
+        },
+        {
+          "verb": "repl",
+          "mode": "help_only",
+          "exit": 0,
+          "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "status": "WARN",
+          "reason": "needs a TTY"
+        }
       ]
     },
     "differential": {
@@ -30,13 +55,38 @@
       "both_fail": 180,
       "compiled_compared": 27,
       "compiled_skipped_budget": 0,
-      "nondeterministic": ["examples/04_collections.ruchy"]
+      "nondeterministic": [
+        "examples/04_collections.ruchy"
+      ]
     },
-    "transpile": { "status": "PASS", "identical": 138, "differs": ["examples/19_string_parameters.ruchy"] },
-    "clean_room": { "status": "PASS", "locked_exit": 0, "unlocked_exit": 0, "binary_version": "5.0.0-beta.1" },
-    "package": { "status": "PASS", "files": 2431, "bytes_compressed": 4194304, "colon_paths": 0, "has_lock": true },
-    "satd": { "status": "PASS", "count": 0, "max": 0 }
+    "transpile": {
+      "status": "PASS",
+      "identical": 138,
+      "differs": [
+        "examples/19_string_parameters.ruchy"
+      ]
+    },
+    "clean_room": {
+      "status": "PASS",
+      "locked_exit": 0,
+      "unlocked_exit": 0,
+      "binary_version": "5.0.0-beta.1"
+    },
+    "package": {
+      "status": "PASS",
+      "files": 2431,
+      "bytes_compressed": 4194304,
+      "colon_paths": 0,
+      "has_lock": true
+    },
+    "satd": {
+      "status": "PASS",
+      "count": 0,
+      "max": 0
+    }
   },
-  "warns": ["verbs: repl help-only (needs a TTY)"],
+  "warns": [
+    "verbs: repl help-only (needs a TTY)"
+  ],
   "verdict": "go"
 }

--- a/tests/release_manifest_lint.rs
+++ b/tests/release_manifest_lint.rs
@@ -267,3 +267,55 @@ fn test_pmat_100_manifest_readers_read_package_and_inline_versions() {
     assert_eq!(inline_dependency_version(wasm, "ruchy"), "1.2.3");
     assert_eq!(inline_dependency_version(wasm, "other"), "");
 }
+
+/// PMAT-129: the wasm32 dependency table must carry what the wasm build of the
+/// root crate needs: getrandom 0.3 with `wasm_js` (rand 0.9 via aprender-core),
+/// `serde-wasm-bindgen` (used by `src/wasm_bindings.rs`), and the two web-sys
+/// canvas features the computebrick entry imports.
+#[test]
+fn test_pmat_129_wasm32_dependency_table_is_complete() {
+    let manifest: toml::Table = read(&manifest_dir().join("Cargo.toml"))
+        .parse()
+        .expect("Cargo.toml parses");
+    let deps = manifest
+        .get("target")
+        .and_then(|t| t.get("cfg(target_arch = \"wasm32\")"))
+        .and_then(|t| t.get("dependencies"))
+        .and_then(|d| d.as_table())
+        .expect("[target.'cfg(target_arch = \"wasm32\")'.dependencies] table");
+    let getrandom03 = deps
+        .values()
+        .filter_map(|v| v.as_table())
+        .find(|t| {
+            t.get("package").and_then(|p| p.as_str()) == Some("getrandom")
+                && t.get("version")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|v| v.starts_with("0.3"))
+        })
+        .expect("getrandom 0.3 declared for wasm32");
+    let features = getrandom03
+        .get("features")
+        .and_then(|f| f.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+        .unwrap_or_default();
+    assert!(
+        features.contains(&"wasm_js"),
+        "getrandom 0.3 needs the wasm_js feature on wasm32; got {features:?}"
+    );
+    assert!(
+        deps.contains_key("serde-wasm-bindgen"),
+        "serde-wasm-bindgen must be a wasm32 dependency, not only a dev-dependency"
+    );
+    let web_sys = deps
+        .get("web-sys")
+        .and_then(|w| w.get("features"))
+        .and_then(|f| f.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
+        .unwrap_or_default();
+    for needed in ["CanvasRenderingContext2d", "HtmlCanvasElement"] {
+        assert!(
+            web_sys.contains(&needed),
+            "web-sys must enable {needed}; got {web_sys:?}"
+        );
+    }
+}

--- a/tests/release_manifest_lint.rs
+++ b/tests/release_manifest_lint.rs
@@ -270,8 +270,8 @@ fn test_pmat_100_manifest_readers_read_package_and_inline_versions() {
 
 /// PMAT-129: the wasm32 dependency table must carry what the wasm build of the
 /// root crate needs: getrandom 0.3 with `wasm_js` (rand 0.9 via aprender-core),
-/// `serde-wasm-bindgen` (used by `src/wasm_bindings.rs`), and the two web-sys
-/// canvas features the computebrick entry imports.
+/// `serde-wasm-bindgen` (used by `src/wasm_bindings.rs`), and the web-sys
+/// canvas context feature the computebrick entry imports.
 #[test]
 fn test_pmat_129_wasm32_dependency_table_is_complete() {
     let manifest: toml::Table = read(&manifest_dir().join("Cargo.toml"))
@@ -312,10 +312,8 @@ fn test_pmat_129_wasm32_dependency_table_is_complete() {
         .and_then(|f| f.as_array())
         .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
         .unwrap_or_default();
-    for needed in ["CanvasRenderingContext2d", "HtmlCanvasElement"] {
-        assert!(
-            web_sys.contains(&needed),
-            "web-sys must enable {needed}; got {web_sys:?}"
-        );
-    }
+    assert!(
+        web_sys.contains(&"CanvasRenderingContext2d"),
+        "web-sys must enable CanvasRenderingContext2d (src/computebrick/wasm_entry.rs); got {web_sys:?}"
+    );
 }

--- a/tests/release_workflow_lint.rs
+++ b/tests/release_workflow_lint.rs
@@ -175,3 +175,22 @@ fn test_pmat_093_required_status_checks_file_names_gate() {
         "required-status-checks.txt must list the `gate` context the org ruleset requires"
     );
 }
+
+/// PMAT-129: on wasm32, getrandom 0.3 (pulled by aprender-core's rand 0.9)
+/// needs the `wasm_js` backend selected through a cfg flag; without it the
+/// Build WASM job fails before `wasm-pack` gets to link anything.
+#[test]
+fn test_pmat_129_wasm_build_step_selects_the_getrandom_wasm_js_backend() {
+    let workflow = std::fs::read_to_string(".github/workflows/release.yml")
+        .expect("failed to read .github/workflows/release.yml");
+    let lines: Vec<&str> = workflow.lines().collect();
+    let step = lines
+        .iter()
+        .position(|line| line.contains("name: Build WASM package"))
+        .expect("release.yml must have a Build WASM package step");
+    let window = lines[step..lines.len().min(step + 8)].join("\n");
+    assert!(
+        window.contains("RUSTFLAGS") && window.contains("getrandom_backend=\"wasm_js\""),
+        "the Build WASM package step must set RUSTFLAGS: --cfg getrandom_backend=\"wasm_js\"; got:\n{window}"
+    );
+}


### PR DESCRIPTION
## Summary

The v5.0.0-beta.2 release run failed in Build WASM before publishing (publish-crates depends on it, as #205 requires). Build WASM has never passed on any tag: v4.2.1 failed there too, v4.2.0 skipped it.

Root cause chain (five whys): aprender-core 0.65 is a non-optional dependency since #207 → its rand 0.9 pulls getrandom 0.3 → on wasm32-unknown-unknown getrandom 0.3 needs the `wasm_js` feature and `--cfg getrandom_backend="wasm_js"` → the repo only configured getrandom 0.2 → nothing ever built the root crate for wasm32 (CI builds default features natively; the gate had no wasm32 stage).

- Manifest: getrandom 0.3 (`wasm_js`), `serde-wasm-bindgen` promoted from dev-only, web-sys canvas features.
- Code: serde derives on the widget spec types, `&mut` where `Transpiler::transpile` needs it, one `wasm_bindgen(start)` hook instead of two.
- Workflow + Makefile: `RUSTFLAGS` selects the backend.
- Gate: stage 2 builds the lib for wasm32 with the same flag (PMAT-130); receipt fixture carries `wasm32`.

## Measured

```
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --lib --target wasm32-unknown-unknown --no-default-features --features wasm-compile   # Finished
cargo test --test release_manifest_lint --test release_workflow_lint --test dogfood_receipt_schema   # 8 + 8 + 7 passed (two new tests RED on the old manifest/workflow)
cargo check --lib   # clean
```

After merge: the GitHub prerelease and tag v5.0.0-beta.2 (created by the failed run, three binary assets, nothing published to crates.io) are removed and the tag re-pointed at the new main to re-drive `release.yml`.

Pmat-Ticket: PMAT-129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
