### PR TITLE
fix(release): intra-workspace path dependencies carry versions; ruchy-embed depends on ruchy 5.0.0-beta.2 [PMAT-137]

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -2760,3 +2760,88 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-133
+  github_issue: null
+  item_type: task
+  title: ruchy 5.0.0-beta.2 manual publish
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-06T06:56:42Z
+  updated: 2026-09-06T06:56:42Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:release
+  notes: null
+- id: PMAT-134
+  github_issue: null
+  item_type: task
+  title: SOVEREIGN-RELEASE-POLICY - policy spec infra/docs/specifications/sovereign-release-policy.md (no-publish-in-ci, no-registry-secret, receipts-at-tag) enforced by a pmat comply org rule; each gate with its falsifier
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-06T06:56:42Z
+  updated: 2026-09-06T06:56:42Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:release
+  notes: null
+- id: PMAT-135
+  github_issue: null
+  item_type: task
+  title: RELEASE-YML-NO-PUBLISH - delete the publish-crates job from release.yml (CI is the gate, the operator is the publisher); replace it with a release-policy gate job; retire release-workflow-v1's publish equations
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-06T06:56:42Z
+  updated: 2026-09-06T06:56:42Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:release
+  notes: null
+- id: PMAT-136
+  github_issue: null
+  item_type: task
+  title: RUCHY-DOGFOOD-SKILL - .claude/skills/ruchy-dogfood/SKILL.md (explicit name, Agent in allowed-tools) modelled on apr-dogfood v3; gates discovered from [package.metadata.dogfood]; three disjoint worker lanes; orchestrator is the single receipt writer; --twice byte-identical
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-06T06:56:42Z
+  updated: 2026-09-06T06:56:42Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:release
+  notes: null
+- id: PMAT-137
+  github_issue: null
+  item_type: task
+  title: 'CLEANROOM-A1-RUCHY-EMBED - infra clean-room hard gate (gates/ruchy.sh) fails at A1 on tag v5.0.0-beta.2 (59c7453b): after A0 strips path deps, ruchy-embed/Cargo.toml depends on ruchy with path only and no version, so cargo generate-lockfile fails; every intra-workspace path dep needs version = alongside path = (guide 4.3)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-06T07:00:41Z
+  updated: 2026-09-06T07:00:41Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:release
+  notes: null

--- a/ruchy-embed/Cargo.toml
+++ b/ruchy-embed/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-ruchy = { path = "..", default-features = false }
+ruchy = { version = "5.0.0-beta.2", path = "..", default-features = false }
 anyhow = "1"
 
 [dev-dependencies]

--- a/tests/release_manifest_lint.rs
+++ b/tests/release_manifest_lint.rs
@@ -317,3 +317,56 @@ fn test_pmat_129_wasm32_dependency_table_is_complete() {
         "web-sys must enable CanvasRenderingContext2d (src/computebrick/wasm_entry.rs); got {web_sys:?}"
     );
 }
+
+/// Dependencies of one manifest section as (name, table) pairs; string-form
+/// entries (`foo = "1.0"`) carry no path and are not returned.
+fn table_dependencies<'a>(
+    manifest: &'a toml::Table,
+    section: &str,
+) -> Vec<(&'a str, &'a toml::Table)> {
+    manifest
+        .get(section)
+        .and_then(|s| s.as_table())
+        .map(|deps| {
+            deps.iter()
+                .filter_map(|(name, value)| value.as_table().map(|t| (name.as_str(), t)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// PMAT-137: the infra clean-room (guide §4.3, gate A0) strips `path` from
+/// every normal and build dependency to simulate what a crates.io consumer
+/// sees; a path-only dependency then has no source and gate A1 fails. Every
+/// intra-workspace `path` dependency therefore carries `version` too.
+/// Dev-dependencies are exempt: `cargo publish` omits path-only dev-deps and
+/// the gate drops them the same way.
+#[test]
+fn test_pmat_137_workspace_path_dependencies_carry_versions() {
+    let root: toml::Table = read(&manifest_dir().join("Cargo.toml"))
+        .parse()
+        .expect("root manifest");
+    let members: Vec<String> = root
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+        .expect("[workspace] members")
+        .iter()
+        .filter_map(|m| m.as_str().map(str::to_string))
+        .collect();
+    let mut violations = Vec::new();
+    for member in &members {
+        let path = manifest_dir().join(member).join("Cargo.toml");
+        let manifest: toml::Table = read(&path).parse().expect("member manifest parses");
+        for section in ["dependencies", "build-dependencies"] {
+            for (name, dep) in table_dependencies(&manifest, section) {
+                if dep.contains_key("path") && !dep.contains_key("version") {
+                    violations.push(format!(
+                        "{member}/Cargo.toml [{section}] {name}: path without version"
+                    ));
+                }
+            }
+        }
+    }
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}


### PR DESCRIPTION
## Summary

The org clean-room hard gate (`infra/machines/clean-room/gates/ruchy.sh`) was run against the tag checkout of v5.0.0-beta.2 (59c7453b) before any manual publish (guide §4.3). It failed at gate A1: after A0 strips `path` from normal dependencies, `ruchy-embed` depended on `ruchy` with no source. Every intra-workspace path dependency now carries `version` (the guide's own rule) and a manifest lint keeps it so.

Measured on a copy of the tag tree with the gate library's own strip commands: this fix removes the ruchy-embed failure; A1 then fails on `ruchy-wasm`'s requirement `ruchy = ^5.0.0-beta.2`, which cannot resolve from crates.io until ruchy itself is published — the gate has no notion of the release subject (PMAT-138, infra).

Evidence: `docs/specifications/evidence/2026-09-05-dogfood/cleanroom-infra-ruchy-59c7453b-A1-fail.log` (in the plan PR).

Pmat-Ticket: PMAT-137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
