### PR TITLE
feat(dogfood): ruchy-dogfood skill — three worker lanes, one receipt writer, gates declared in Cargo.toml [PMAT-136]

### DIFF
--- a/.claude/skills/ruchy-dogfood/SKILL.md
+++ b/.claude/skills/ruchy-dogfood/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: ruchy-dogfood
+description: Dogfood the ruchy compiler before a release — CLI surface from the built binary, the book/examples corpus through it, wasm32 and a fresh-container install; three read-only worker lanes, one receipt writer.
+allowed-tools: Agent, Bash(cargo:*), Bash(git:*), Bash(gh:*), Bash(pmat:*), Bash(docker:*), Bash(bash:*), Bash(jq:*), Bash(find:*), Bash(grep:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(diff:*), Bash(sha256sum:*), Read, Write
+---
+
+# ruchy-dogfood — the pre-release protocol for the ruchy compiler
+
+The gate between "CI is green" and a ruchy release. It asks four questions the
+test suite does not: does the shipped binary's *verb surface* work, does the
+*corpus people actually read* still run through it, does wasm32 still build, and
+does a stranger on a clean machine get a working `ruchy`.
+
+**Toyota way, non-negotiable:** any RED gate STOPS the release. Fix the root
+cause in this crate. Never `--no-verify`, never `--skip`, never lower a floor to
+make a row go green.
+
+The frontmatter carries an explicit `name: ruchy-dogfood`. It has to: a skill
+directory named `dogfood` is shadowed by the user-scope `~/.claude/skills/dogfood`
+(the fleet's crate-generic protocol), and a shadowed skill is a protocol nobody
+runs. This one is ruchy-specific and lives in ruchy's tree, in git.
+
+## Every gate has a SUBJECT
+
+Read this before adding a gate, and before calling a permanently-red one debt.
+
+| gate | subject | when it can pass |
+|---|---|---|
+| lane 1 surface, lane 2 corpus | **this tree's built binary** | now |
+| `scripts/wasm32-build.sh` | **this tree** | now |
+| lane 3 fresh-container install | the **published crate**, on a clean host | only AFTER publish |
+| the declared gates in `Cargo.toml` | **this tree** | now |
+
+A gate whose subject is a later phase is not broken and is not debt. Before the
+version in `Cargo.toml` exists on crates.io, the container lane records
+`not-yet-measured` **with the reason**, and never `PASS`. Treating that RED as
+debt is how it becomes a step everyone learns to walk past; recording it as PASS
+is a lie about a thing that was never measured.
+
+## Status vocabulary and exits
+
+Rows are `PASS` / `FAIL` / `SKIP` / `REPORT` / `not-yet-measured`. A `SKIP` must
+record the enumeration that found nothing ("0 files from `find examples -name
+'*.ruchy'`") so *no subject* can be told apart from *did not look*. A `REPORT` is
+a deliberate non-gating measurement and must carry the number **and** the ticket
+it waits on. Do not add `WARN`: a WARN in a release protocol is a step everybody
+learns to walk past.
+
+Exits: **0 = GO**, **1 = NO-GO**, **2 = harness failure** (the protocol could not
+run: a lane crashed, a required tool is missing, a lane file never appeared),
+**3 = the receipt just written is unreadable** (verdict withheld — a verdict
+nobody can re-read is not evidence).
+
+**GO iff** every lane is PASS, every declared gate is PASS, and the receipt reads
+back. Anything else is NO-GO.
+
+## Shape of a run
+
+The **orchestrator** is the session running this skill (Fable). It spawns at
+**depth 1 only** — workers never spawn workers — and at most **three** at a time:
+
+```bash
+export CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS=3
+```
+
+Three lanes run concurrently. Each is a `paiml-impl-worker`-style **read-only**
+worker: it may read anything in the tree and run the built binary, and it may
+write **exactly one file — its own**. Each lane's Agent `description` must start
+with `<ticket>/ph<i>` (e.g. `PMAT-136/ph1 surface audit`); `receipt-lint.sh`
+refuses a receipt whose lane descriptions do not, because a lane that cannot be
+attributed to a ticket and a phase cannot be re-run by anyone but its author.
+
+The orchestrator is the **single receipt writer**. Workers never write the
+receipt, never commit, never push, never open a PR, never publish.
+
+### Lane 1 — surface + coverage (Sonnet, ≤40 turns)
+
+Scope: `docs/audits/surface_audit.csv`, `out/lane-1.json`.
+
+Enumerate the verb tree **from the built binary**, never from `src/` and never
+from the docs: `ruchy --help`, then `--help` for every subcommand it lists,
+recursively to a fixed point. A surface read out of the source is a claim about
+the code; a surface read out of the binary is a measurement of the release.
+
+Write `docs/audits/surface_audit.csv` with the header
+`verb,has_help,smoke_result,covered_by_corpus` — one row per verb, where
+`has_help` records that `--help` exited 0 and printed a usage line,
+`smoke_result` is the verb's minimal invocation (`PASS` / `FAIL` /
+`REPORT <reason>`), and `covered_by_corpus` is `yes` / `no`: whether lane 2's
+file set exercises that verb. Then `out/lane-1.json`:
+
+```json
+{"lane":1,"verdict":"PASS","verbs":42,"undocumented":[],"uncovered":["wasm"],"rows":[]}
+```
+
+A verb with no `--help` is FAIL. A verb the corpus never touches is not FAIL —
+it is the `uncovered` list, and it is this lane's most useful output.
+
+### Lane 2 — exercise the covered set (Sonnet)
+
+Scope: `out/lane-2.json`.
+
+Run every `.ruchy` file under `examples/` and under each sibling corpus that
+exists — `../ruchy-book`, `../ruchy-cookbook`, `../rosetta-ruchy`,
+`../ruchy-repl-demos` — through the **built** binary, each with `timeout 10`
+(the hang guard from CLAUDE.md's Ruchy Execution Safety Protocol; a runaway
+`ruchy` has cost this project a whole session before).
+
+A **missing corpus is recorded, never silently skipped**: it lands in
+`missing_corpora` with the path that was looked for. `scripts/book-corpus.sh`
+already performs exactly this enumeration and prints
+`files=N pass=N fail=N missing_corpora=[…]`; the lane uses it and adds the
+per-file detail.
+
+```json
+{"lane":2,"verdict":"PASS","missing_corpora":[],
+ "files":[{"path":"examples/01_hello.ruchy","verb":"check","exit":0,
+           "stdout_sha256":"…","seconds":0.04}]}
+```
+
+Failures under `examples/` are gating — those files are this repo's. Failures
+under a sibling corpus are `REPORT` rows naming the corpus: they are another
+repo's tree, and their red is that repo's ticket, not a reason to hold this
+release. Never drop them silently.
+
+### Lane 3 — wasm32 + fresh container (Sonnet)
+
+Scope: `out/lane-3.json`.
+
+1. `bash scripts/wasm32-build.sh` — the same command the release workflow's WASM
+   job runs: `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --lib
+   --target wasm32-unknown-unknown --no-default-features --features wasm-compile`.
+   The target's absence is FAIL, never a skip.
+2. The fresh-container install, whose subject is the **published artifact**:
+
+```bash
+docker run --rm rust:1.91-slim bash -lc \
+  'cargo install ruchy --version <v> --locked && ruchy --version'
+# then the same again without --locked
+```
+
+`<v>` is the version in `Cargo.toml`. Both forms are run: `--locked` proves the
+published `Cargo.lock` resolves, unlocked proves the crate still builds against
+today's registry — the two fail for different reasons, and a green `--locked` has
+hidden a broken unlocked build before.
+
+**Before publish this lane's second half cannot pass.** The version is not on
+crates.io yet, so the row is
+
+```json
+{"status":"not-yet-measured",
+ "reason":"ruchy <v> is not on crates.io; the container's subject is the published artifact (post-publish phase)"}
+```
+
+— never `PASS`, never `SKIP`. It is produced for real in the post-publish phase,
+and the receipt from that phase is what closes it.
+
+```json
+{"lane":3,"verdict":"PASS","wasm32":{"status":"PASS","seconds":91},
+ "container":{"status":"not-yet-measured","reason":"…"}}
+```
+
+## Rules the lanes obey
+
+1. **Read-only except one file.** A worker that writes anything else — source,
+   `Cargo.toml`, another lane's output, the receipt — invalidates the run.
+2. **Never push.** No pushes, no PRs, no `cargo publish`, no `gh release` from a
+   worker. The orchestrator performs the release, after a GO.
+3. **A lane `.err` file, or a lane file that never appears, is NO-GO.** Not a
+   retry, not a skip: a lane that did not report did not measure.
+4. **Deterministic-tool absence is NO-GO, never a silent skip.**
+   `pmat work show <ticket>` must succeed before the lanes start — the ticket
+   this run belongs to has to exist. If the installed pmat has no such verb
+   (measured 2026-09-06: pmat 3.38.0 exposes `work list|annotate|start|…` and no
+   `show`), that is a **FAIL row naming the version**, not a skip. The remedy is
+   upstream in pmat; the receipt says so out loud rather than quietly dropping
+   the check.
+5. **Repo gates are discovered, never copied.** `[package.metadata.dogfood] gates`
+   in `Cargo.toml` is the list; `bash scripts/dogfood-gates.sh` runs it and gives
+   each gate **its own row**. A declared script that does not exist is a deleted
+   gate → `FAIL <script> missing`. An empty or absent list is a clean sweep over
+   an empty set → `FAIL no gates declared`. Both are hard FAILs; neither is a
+   SKIP. `bash scripts/dogfood-gates.sh --list` prints the list without running
+   it, and `tests/dogfood_gates_declared.rs` proves `--list` and the manifest
+   agree. Adding a gate is an edit to `Cargo.toml`, never an edit to this file.
+6. **One receipt writer.** The orchestrator merges `out/lane-1.json`,
+   `out/lane-2.json`, `out/lane-3.json` and the gate rows into
+   `.dogfood/receipt-<sha>.json`, where `<sha>` is `git rev-parse HEAD` — the
+   commit the receipt describes. It is written as
+   `.dogfood/receipt-<sha>.json.partial` and **atomically renamed** on
+   completion, so a crashed run leaves no completed receipt rather than a stale
+   or truncated one. A partial run never prints GO.
+7. **The receipt carries no timestamps.** It is a statement about a commit, not
+   about a moment, and a timestamp would make byte-comparison useless.
+8. **`--twice` runs the whole protocol twice and diffs the two receipts.** Any
+   byte difference is NO-GO: a protocol whose verdict moves while the tree does
+   not is measuring something other than the tree. Print the diff.
+9. `.dogfood/` is created by this protocol and is in `.gitignore`. Receipts are
+   not committed to the tree; they are attached to the release.
+
+## Run it
+
+```bash
+export CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS=3
+pmat work show <TICKET>                 # the ticket must exist (rule 4)
+bash scripts/dogfood-gates.sh --list    # what will run
+bash scripts/dogfood-gates.sh           # the declared gates, one row each
+# then the three lanes, concurrently, then the receipt
+```
+
+Read the receipt back with `jq . .dogfood/receipt-<sha>.json` before printing any
+verdict. If it does not parse, exit 3 and withhold the verdict.
+
+## On GO
+
+1. Tag the commit the receipt names (`v<version>`) and push that tag, or run the
+   repo's release workflow.
+2. Publish, then re-run **lane 3 only** — its container half now has a subject
+   that exists — and keep that second receipt.
+3. Create the GitHub release from the tag and attach the receipt as
+   `dogfood-receipt-<sha>.json`. A release with no receipt attached has no
+   evidence, and evidence nobody can find is evidence nobody checked.
+
+## On NO-GO
+
+Stop. Print every red row with its note *before* the verdict — a verdict that
+says only "a gate failed" makes the reader hunt for it, and the hunt is where
+bypasses start. File the failing gate as a pmat ticket, naming the receipt path
+and the row; fix the root cause with five-whys; commit; re-run this protocol.
+Never release on a NO-GO.

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dependency_cleanup_analysis.md
 # RIGHTWARDS ARROW used in some Apex Hunt directory names), so one pattern
 # covers every observed variant — all of them start with "Apex Hunt: ...".
 .pmat-work/*:*
+
+# PMAT-136: dogfood receipts (written by the ruchy-dogfood skill)
+.dogfood/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -641,3 +641,16 @@ required-features = ["repl"]
 [[example]]
 name = "test_mutation"
 required-features = ["repl"]
+
+# PMAT-136: the ruchy-dogfood protocol DISCOVERS this repo's own release gates
+# here and runs each one with its own receipt row -- it never carries a copy of
+# them. A declared script that does not exist is a deleted gate (FAIL), and an
+# empty list is a clean sweep over an empty set (FAIL).
+# scripts/release-policy.sh is written by PMAT-135; until that branch merges it
+# is declared here and absent from the tree, and its FAIL is expected.
+[package.metadata.dogfood]
+gates = [
+    "scripts/release-policy.sh",
+    "scripts/wasm32-build.sh",
+    "scripts/book-corpus.sh",
+]

--- a/contracts/dogfood-gates-v1.yaml
+++ b/contracts/dogfood-gates-v1.yaml
@@ -1,0 +1,90 @@
+metadata:
+  version: "1.0.0"
+  author: "Sovereign AI Stack"
+  description: "Gate-discovery contract for the ruchy-dogfood pre-release protocol: a repo's release gates are DECLARED in Cargo.toml and discovered, never copied into the protocol, and the absence of a declared gate is a FAIL (PMAT-136)"
+  crate: "ruchy"
+  references:
+    - ".claude/skills/ruchy-dogfood/SKILL.md (the protocol)"
+    - "scripts/dogfood-gates.sh (the discovery runner)"
+    - "contracts/test-feature-gates-v1.yaml (PMAT-112/113, same shape)"
+    - "docs/specifications/ruchy-5.0.0-beta.2-release-plan.md §2 Z5 (pre-release gate)"
+
+equations:
+  gates_declared_not_copied:
+    formula: "gates(protocol) = strings([package.metadata.dogfood].gates ∈ Cargo.toml)"
+    domain: "Cargo.toml [package.metadata.dogfood] and scripts/dogfood-gates.sh --list"
+    invariants:
+      - "The protocol carries no copy of a repo gate: adding a gate is an edit to Cargo.toml, never to SKILL.md"
+      - "scripts/dogfood-gates.sh --list prints exactly the declared list, in declaration order"
+      - "Each declared gate gets its own receipt row: PASS|FAIL <script> <seconds>"
+  absence_is_fail:
+    formula: "¬exists(g) ⇒ row(g) = FAIL ∧ gates = ∅ ⇒ verdict = FAIL"
+    domain: "scripts/dogfood-gates.sh over a manifest whose gates are missing, empty, or name absent scripts"
+    invariants:
+      - "A declared script that does not exist is a deleted gate: FAIL <script> missing, never SKIP"
+      - "An empty or absent gates list is a clean sweep over an empty set: FAIL no gates declared"
+      - "A gate that cannot run is FAIL with a reason; deterministic-tool absence is never silent"
+      - "Exit is 1 whenever any row is FAIL"
+
+proof_obligations:
+  - type: completeness
+    property: "Every gate the protocol runs comes from the declaration, and every declared gate produces a row"
+    formal: "gates_declared_not_copied"
+    applies_to: all
+  - type: soundness
+    property: "No missing or unmeasured gate can be reported as passing"
+    formal: "absence_is_fail"
+    applies_to: all
+
+falsification_tests:
+  - id: FALSIFY-DOGFOOD-GATES-001
+    rule: "The declaration exists and is non-empty"
+    test: "test_pmat_136_dogfood_gates_table_declares_a_non_empty_list"
+    prediction: "verified"
+    if_fails: "Contract violation — an empty gates list is a clean sweep over an empty set"
+  - id: FALSIFY-DOGFOOD-GATES-002
+    rule: "Every declared gate exists and is executable"
+    test: "test_pmat_136_every_declared_gate_exists_and_is_executable"
+    prediction: "verified"
+    if_fails: "Contract violation — a declared-but-missing gate is a deleted gate the protocol would sweep over"
+  - id: FALSIFY-DOGFOOD-GATES-003
+    rule: "The cross-ticket exemption disappears when the gate lands"
+    test: "test_pmat_136_pending_allowlist_is_empty_once_the_gate_lands"
+    prediction: "verified"
+    if_fails: "Contract violation — PENDING_FROM_OTHER_TICKETS outlived PMAT-135 and now hides a real absence"
+  - id: FALSIFY-DOGFOOD-GATES-004
+    rule: "The skill is named and may spawn its lanes"
+    test: "test_pmat_136_skill_frontmatter_names_the_skill_and_allows_agent"
+    prediction: "verified"
+    if_fails: "Contract violation — the skill is shadowed by the user-scope dogfood skill, or cannot spawn its three lanes"
+  - id: FALSIFY-DOGFOOD-GATES-005
+    rule: "Discovery output equals the declaration"
+    test: "test_pmat_136_dogfood_gates_list_matches_the_declaration"
+    prediction: "verified"
+    if_fails: "Discovery defect — the runner reads a different set than Cargo.toml declares, so a gate is run or skipped unannounced"
+
+kani_harnesses:
+  - id: KANI-DOGFOOD-GATES-001
+    obligation: PO-DOGFOOD-GATES-001
+    property: "gates_declared_not_copied"
+    bound: 8
+    strategy: bounded_int
+    harness: verify_dogfood_gates_declared
+  - id: KANI-DOGFOOD-GATES-002
+    obligation: PO-DOGFOOD-GATES-002
+    property: "absence_is_fail"
+    bound: 8
+    strategy: bounded_int
+    harness: verify_dogfood_absence_is_fail
+
+qa_gate:
+  id: QA-DOGFOOD-GATES
+  name: "dogfood gate discovery contract"
+  min_coverage: 0.90
+  max_complexity: 10
+  required_tests:
+    - "test_pmat_136_dogfood_gates_table_declares_a_non_empty_list"
+    - "test_pmat_136_every_declared_gate_exists_and_is_executable"
+    - "test_pmat_136_pending_allowlist_is_empty_once_the_gate_lands"
+    - "test_pmat_136_skill_frontmatter_names_the_skill_and_allows_agent"
+    - "test_pmat_136_dogfood_gates_list_matches_the_declaration"

--- a/scripts/book-corpus.sh
+++ b/scripts/book-corpus.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# PMAT-136 -- run the BUILT binary over the examples and the book corpora.
+#
+# Subject: this tree's examples/ (gating) plus the sibling book repos
+# (informational -- they are other repos' trees and their red is their ticket,
+# but a MISSING corpus is always recorded, never silently skipped).
+#
+# Each file is checked with `timeout 10 <bin> check <file>`; the timeout is the
+# hang guard (CLAUDE.md, Ruchy Execution Safety Protocol).
+#
+# Usage:
+#   bash scripts/book-corpus.sh            # build (or $RUCHY_BIN) and check every file
+#   bash scripts/book-corpus.sh --dry-run  # list the files and corpora, build nothing
+#
+# Environment:
+#   RUCHY_BIN         path to the binary to exercise (else cargo build --release)
+#   CARGO_TARGET_DIR  honoured when locating the built binary
+#
+# Exit: 1 if any file under examples/ fails `check` (or the build fails), else 0.
+
+set -u -o pipefail
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)
+SIBLINGS="ruchy-book ruchy-cookbook rosetta-ruchy ruchy-repl-demos"
+MISSING=""
+PRESENT=""
+
+usage() {
+    echo "usage: bash scripts/book-corpus.sh [--dry-run]" >&2
+}
+
+# Print every *.ruchy file under a directory, sorted; nothing if it is absent.
+corpus_files() {
+    local dir=$1
+    [ -d "$dir" ] || return 0
+    find "$dir" -type f -name '*.ruchy' | sort
+}
+
+# Split the sibling corpora into PRESENT and MISSING. Called in the current
+# shell, never in a command substitution: a subshell would lose MISSING, and a
+# corpus that was never looked at would read as a corpus with no findings.
+scan_siblings() {
+    local name dir parent
+    parent=$(dirname "$ROOT")
+    for name in $SIBLINGS; do
+        dir="$parent/$name"
+        if [ -d "$dir" ]; then
+            PRESENT="$PRESENT $dir"
+        else
+            MISSING="$MISSING $name"
+        fi
+    done
+}
+
+# The binary to exercise: $RUCHY_BIN, else a release build of this tree.
+resolve_bin() {
+    local target_dir
+    if [ -n "${RUCHY_BIN:-}" ]; then
+        echo "$RUCHY_BIN"
+        return 0
+    fi
+    target_dir=${CARGO_TARGET_DIR:-$ROOT/target}
+    (cd "$ROOT" && cargo build --release) >&2 || return 1
+    echo "$target_dir/release/ruchy"
+}
+
+# Check every file on stdin; report each failure on stderr; echo "<pass> <fail>".
+check_files() {
+    local bin=$1 label=$2 pass=0 fail=0 file
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        if timeout 10 "$bin" check "$file" > /dev/null 2>&1; then
+            pass=$((pass + 1))
+        else
+            fail=$((fail + 1))
+            echo "  fail($label) $file" >&2
+        fi
+    done
+    echo "$pass $fail"
+}
+
+summary() {
+    local files=$1 pass=$2 fail=$3 missing
+    missing=$(echo "$MISSING" | tr -s ' ' ',' | sed 's/^,//; s/,$//')
+    echo "files=$files pass=$pass fail=$fail missing_corpora=[$missing]"
+}
+
+dry_run() {
+    local dir all
+    all=$(corpus_files "$ROOT/examples")
+    scan_siblings
+    for dir in $PRESENT; do
+        echo "corpus $dir"
+        all="$all"$'\n'$(corpus_files "$dir")
+    done
+    printf '%s\n' "$all" | sed '/^$/d'
+    # not-run, not 0: a dry run has measured nothing, and a zero would read
+    # as a measurement that found nothing wrong.
+    summary "$(printf '%s\n' "$all" | sed '/^$/d' | wc -l)" not-run not-run
+    exit 0
+}
+
+full_run() {
+    local bin dir counts examples_fail total_pass=0 total_fail=0 files=0
+    bin=$(resolve_bin) || { echo "FAIL cannot build or locate the ruchy binary"; exit 1; }
+    scan_siblings
+    counts=$(corpus_files "$ROOT/examples" | check_files "$bin" examples)
+    examples_fail=$(echo "$counts" | cut -d' ' -f2)
+    total_pass=$(echo "$counts" | cut -d' ' -f1)
+    total_fail=$examples_fail
+    for dir in $PRESENT; do
+        counts=$(corpus_files "$dir" | check_files "$bin" "$(basename "$dir")")
+        total_pass=$((total_pass + $(echo "$counts" | cut -d' ' -f1)))
+        total_fail=$((total_fail + $(echo "$counts" | cut -d' ' -f2)))
+    done
+    files=$((total_pass + total_fail))
+    summary "$files" "$total_pass" "$total_fail"
+    [ "$examples_fail" -eq 0 ] || exit 1
+    exit 0
+}
+
+case ${1:-run} in
+    --dry-run) dry_run ;;
+    run) full_run ;;
+    *) usage; exit 2 ;;
+esac

--- a/scripts/dogfood-gates.sh
+++ b/scripts/dogfood-gates.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# PMAT-136 -- run the release gates this repo DECLARES, one row each.
+#
+# The dogfood protocol never carries a copy of a repo's own gates. It reads them
+# from Cargo.toml:
+#
+#   [package.metadata.dogfood]
+#   gates = ["scripts/release-policy.sh", "scripts/wasm32-build.sh", ...]
+#
+# Both vacuity guards are hard FAILs, never skips:
+#   * a declared script that does not exist is a DELETED gate -> FAIL <script> missing
+#   * an empty or absent gates list is a clean sweep over an empty set
+#     -> FAIL no gates declared
+#
+# Usage:
+#   bash scripts/dogfood-gates.sh --list   # print the declared gates, one per line
+#   bash scripts/dogfood-gates.sh          # run each, print "PASS|FAIL <script> <seconds>"
+#
+# Exit: 0 every gate passed, 1 any FAIL, 2 usage error.
+# The gates list is read with awk/sed -- no TOML library, so this script has no
+# build step and runs before anything is compiled.
+
+set -u -o pipefail
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)
+MANIFEST="$ROOT/Cargo.toml"
+
+usage() {
+    echo "usage: bash scripts/dogfood-gates.sh [--list]" >&2
+}
+
+# Print the strings of the `gates` array in [package.metadata.dogfood], one per line.
+extract_gates() {
+    awk '
+        /^[[:space:]]*\[/ { in_table = ($0 ~ /^[[:space:]]*\[package\.metadata\.dogfood\]/); next }
+        !in_table { next }
+        /^[[:space:]]*gates[[:space:]]*=/ { collecting = 1 }
+        collecting { buf = buf $0; if ($0 ~ /\]/) { collecting = 0 } }
+        END { print buf }
+    ' "$MANIFEST" | grep -o '"[^"]*"' | sed 's/"//g'
+}
+
+# Run one gate. Prints its row; returns 0 on PASS, 1 on FAIL.
+run_gate() {
+    local gate=$1
+    local start log status elapsed
+    if [ ! -f "$ROOT/$gate" ]; then
+        echo "FAIL $gate missing"
+        return 1
+    fi
+    start=$SECONDS
+    log=$(bash "$ROOT/$gate" 2>&1)
+    status=$?
+    elapsed=$((SECONDS - start))
+    if [ "$status" -eq 0 ]; then
+        echo "PASS $gate ${elapsed}s"
+        return 0
+    fi
+    echo "FAIL $gate ${elapsed}s"
+    printf '%s\n' "$log" | tail -20 | sed 's/^/    | /'
+    return 1
+}
+
+main() {
+    local mode gates failed gate
+    mode=${1:-run}
+    if [ "$mode" != "run" ] && [ "$mode" != "--list" ]; then
+        usage
+        exit 2
+    fi
+
+    gates=$(extract_gates)
+    if [ -z "$gates" ]; then
+        echo "FAIL no gates declared"
+        exit 1
+    fi
+
+    if [ "$mode" = "--list" ]; then
+        printf '%s\n' "$gates"
+        exit 0
+    fi
+
+    failed=0
+    while IFS= read -r gate; do
+        [ -n "$gate" ] || continue
+        run_gate "$gate" || failed=$((failed + 1))
+    done <<< "$gates"
+
+    echo "gates=$(printf '%s\n' "$gates" | wc -l) failed=$failed"
+    [ "$failed" -eq 0 ] || exit 1
+    exit 0
+}
+
+main "$@"

--- a/scripts/dogfood-gates.sh
+++ b/scripts/dogfood-gates.sh
@@ -27,12 +27,15 @@ ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)
 MANIFEST="$ROOT/Cargo.toml"
 
 usage() {
-    echo "usage: bash scripts/dogfood-gates.sh [--list]" >&2
+    echo "usage: bash scripts/dogfood-gates.sh [--list] [--manifest <Cargo.toml>]" >&2
 }
 
 # Print the strings of the `gates` array in [package.metadata.dogfood], one per line.
+# Comments are dropped first: a `]` or a quoted name inside a comment must neither end
+# the array early nor become a phantom gate (quorum on #220).
 extract_gates() {
     awk '
+        { sub(/#.*$/, "") }
         /^[[:space:]]*\[/ { in_table = ($0 ~ /^[[:space:]]*\[package\.metadata\.dogfood\]/); next }
         !in_table { next }
         /^[[:space:]]*gates[[:space:]]*=/ { collecting = 1 }
@@ -63,12 +66,15 @@ run_gate() {
 }
 
 main() {
-    local mode gates failed gate
-    mode=${1:-run}
-    if [ "$mode" != "run" ] && [ "$mode" != "--list" ]; then
-        usage
-        exit 2
-    fi
+    local mode=run gates failed gate
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --list) mode="list"; shift ;;
+            --manifest) MANIFEST=${2:-}; [ -n "$MANIFEST" ] || { usage; exit 2; }; shift 2 ;;
+            run) shift ;;
+            *) usage; exit 2 ;;
+        esac
+    done
 
     gates=$(extract_gates)
     if [ -z "$gates" ]; then
@@ -76,7 +82,7 @@ main() {
         exit 1
     fi
 
-    if [ "$mode" = "--list" ]; then
+    if [ "$mode" = "list" ]; then
         printf '%s\n' "$gates"
         exit 0
     fi

--- a/scripts/pre-release-gate.sh
+++ b/scripts/pre-release-gate.sh
@@ -220,25 +220,14 @@ stage_features() {
     clippy_run all --all-features; a=$?
     clippy_run minimal --no-default-features --features minimal; m=$?
 
-    # wasm32: the release workflow's Build WASM job (PMAT-129/130). getrandom 0.3 (via
-    # aprender-core's rand 0.9) needs the wasm_js backend both as a feature (Cargo.toml,
-    # wasm32 table) and as a cfg flag; the flag is set here exactly as release.yml sets it.
-    if ! rustup target list --installed 2> /dev/null | grep -qx 'wasm32-unknown-unknown'; then
-        say "  installing the wasm32-unknown-unknown target ..."
-        rustup target add wasm32-unknown-unknown > "$WORK/wasm32-target.log" 2>&1 || true
-    fi
-    if rustup target list --installed 2> /dev/null | grep -qx 'wasm32-unknown-unknown'; then
-        say "  build (wasm32-unknown-unknown, --no-default-features --features wasm-compile) ..."
-        (cd "$ROOT" && RUSTFLAGS='--cfg getrandom_backend="wasm_js"' command cargo build --lib \
-            --target wasm32-unknown-unknown --no-default-features --features wasm-compile) \
-            > "$WORK/wasm32.log" 2>&1
-        w=$?
-        [ "$w" -eq 0 ] || tail -20 "$WORK/wasm32.log"
-        say "  wasm32 exit=$w"
-    else
-        w=127
-        say "  wasm32-unknown-unknown target unavailable -- the wasm build FAILS the stage (never skipped silently)"
-    fi
+    # wasm32: the release workflow's Build WASM job (PMAT-129/130). The command lives
+    # once, in scripts/wasm32-build.sh, which the dogfood protocol also declares as a
+    # gate (PMAT-136): a missing target fails there, never silently.
+    say "  build (wasm32-unknown-unknown via scripts/wasm32-build.sh) ..."
+    bash "$ROOT/scripts/wasm32-build.sh" > "$WORK/wasm32.log" 2>&1
+    w=$?
+    [ "$w" -eq 0 ] || tail -20 "$WORK/wasm32.log"
+    say "  wasm32 exit=$w"
 
     if rustup run "$CI_TOOLCHAIN" cargo --version > /dev/null 2>&1; then
         (cd "$ROOT" && command cargo "+$CI_TOOLCHAIN" fmt --all -- --check) > "$WORK/fmt.log" 2>&1

--- a/scripts/wasm32-build.sh
+++ b/scripts/wasm32-build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PMAT-136 -- the wasm32 build gate, as a standalone declared gate.
+#
+# This is the exact command scripts/pre-release-gate.sh stage 2 runs (and the one
+# the release workflow's Build WASM job runs): getrandom 0.3 needs its wasm_js
+# backend selected both as a dependency feature and as a cfg flag, so RUSTFLAGS
+# carries the cfg here the same way release.yml sets it (PMAT-129/130).
+#
+# The target's absence is a FAIL, never a silent skip: an unmeasured gate must
+# say which of the two states it is in.
+#
+# CARGO_TARGET_DIR is honoured -- it is passed through to cargo untouched.
+# Exit code is cargo's.
+
+set -u -o pipefail
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)
+TARGET=wasm32-unknown-unknown
+
+has_target() {
+    rustup target list --installed 2> /dev/null | grep -qx "$TARGET"
+}
+
+if ! has_target; then
+    echo "installing the $TARGET target ..."
+    rustup target add "$TARGET" || echo "rustup target add $TARGET did not succeed"
+fi
+
+if ! has_target; then
+    echo "FAIL $TARGET unavailable -- the wasm build cannot be measured"
+    exit 1
+fi
+
+cd "$ROOT" || exit 2
+RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --lib \
+    --target "$TARGET" --no-default-features --features wasm-compile

--- a/tests/dogfood_gates_declared.rs
+++ b/tests/dogfood_gates_declared.rs
@@ -163,3 +163,31 @@ fn test_pmat_136_dogfood_gates_list_matches_the_declaration() {
         "--list must print exactly the gates declared in Cargo.toml"
     );
 }
+
+/// PMAT-136 (quorum on #220): a `]` or a quoted name inside a comment must neither
+/// end the array early nor become a phantom gate.
+#[test]
+fn test_pmat_136_gate_discovery_ignores_comments_in_the_manifest() {
+    let dir = std::env::temp_dir().join(format!("pmat136-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let manifest = dir.join("Cargo.toml");
+    std::fs::write(
+        &manifest,
+        "[package]\nname = \"x\"\n[package.metadata.dogfood]\n# gates = [\"phantom\"] ]\ngates = [\n    \"scripts/a.sh\", # first ] not the end\n    \"scripts/b.sh\",\n]\n",
+    )
+    .expect("write manifest");
+    let output = Command::new("bash")
+        .arg("scripts/dogfood-gates.sh")
+        .arg("--list")
+        .arg("--manifest")
+        .arg(&manifest)
+        .output()
+        .expect("run scripts/dogfood-gates.sh --list --manifest");
+    let _ = std::fs::remove_dir_all(&dir);
+    let listed = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        listed.trim(),
+        "scripts/a.sh\nscripts/b.sh",
+        "listed: {listed:?}"
+    );
+}

--- a/tests/dogfood_gates_declared.rs
+++ b/tests/dogfood_gates_declared.rs
@@ -1,0 +1,165 @@
+//! PMAT-136: the ruchy-dogfood skill's release gates are DECLARED, never copied.
+//!
+//! The dogfood protocol discovers a repo's own gates from
+//! `[package.metadata.dogfood] gates` in `Cargo.toml` and runs each one with its
+//! own receipt row. Two vacuity guards make discovery honest:
+//!
+//! * a declared script that does not exist is a *deleted* gate -> FAIL
+//! * an empty (or missing) `gates` list is a clean sweep over an empty set -> FAIL
+//!
+//! These tests are the falsification harness for `contracts/dogfood-gates-v1.yaml`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Gates declared here but owned by another in-flight ticket.
+///
+/// `scripts/release-policy.sh` is written by PMAT-135 on its own branch. Until
+/// that branch merges the file is absent from this worktree, and the
+/// declared-but-missing rule would fire on it for a reason that is not a defect
+/// of this tree. The allowlist is deliberately narrow: one name, and
+/// `test_pmat_136_pending_allowlist_is_empty_once_the_gate_lands` deletes the
+/// exemption the moment the file appears.
+const PENDING_FROM_OTHER_TICKETS: [&str; 1] = ["scripts/release-policy.sh"];
+
+/// The crate root, independent of the caller's working directory.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The `gates` list from `[package.metadata.dogfood]`, parsed with the `toml` crate.
+fn declared_gates() -> Vec<String> {
+    let manifest = fs::read_to_string(repo_root().join("Cargo.toml")).expect("read Cargo.toml");
+    let doc: toml::Value = toml::from_str(&manifest).expect("Cargo.toml is not valid TOML");
+    let gates = doc
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("dogfood"))
+        .and_then(|d| d.get("gates"))
+        .expect("[package.metadata.dogfood] gates is missing from Cargo.toml");
+    gates
+        .as_array()
+        .expect("[package.metadata.dogfood] gates must be an array")
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .expect("every declared gate must be a string")
+                .to_string()
+        })
+        .collect()
+}
+
+/// True when the ticket that owns this gate has not merged yet.
+fn is_pending_from_another_ticket(gate: &str) -> bool {
+    PENDING_FROM_OTHER_TICKETS.contains(&gate)
+}
+
+#[test]
+fn test_pmat_136_dogfood_gates_table_declares_a_non_empty_list() {
+    let gates = declared_gates();
+    assert!(
+        !gates.is_empty(),
+        "an empty gates list is a clean sweep over an empty set: declare the repo's gates"
+    );
+}
+
+#[test]
+fn test_pmat_136_every_declared_gate_exists_and_is_executable() {
+    for gate in declared_gates() {
+        if is_pending_from_another_ticket(&gate) {
+            continue;
+        }
+        let path = repo_root().join(&gate);
+        assert!(
+            path.is_file(),
+            "declared gate {gate} does not exist: a declared-but-missing gate is a deleted gate"
+        );
+        assert_executable(&path, &gate);
+    }
+}
+
+#[cfg(unix)]
+fn assert_executable(path: &std::path::Path, gate: &str) {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = fs::metadata(path)
+        .expect("stat declared gate")
+        .permissions()
+        .mode();
+    assert!(
+        mode & 0o111 != 0,
+        "declared gate {gate} is not executable (mode {mode:o})"
+    );
+}
+
+#[cfg(not(unix))]
+fn assert_executable(_path: &std::path::Path, _gate: &str) {}
+
+#[test]
+fn test_pmat_136_pending_allowlist_is_empty_once_the_gate_lands() {
+    for gate in PENDING_FROM_OTHER_TICKETS {
+        assert!(
+            !repo_root().join(gate).is_file(),
+            "{gate} now exists: remove it from PENDING_FROM_OTHER_TICKETS so the \
+             declared-but-missing rule covers it again (PMAT-135 has merged)"
+        );
+    }
+}
+
+/// The YAML frontmatter block of the skill, without its `---` fences.
+fn skill_frontmatter() -> String {
+    let path = repo_root().join(".claude/skills/ruchy-dogfood/SKILL.md");
+    let text = fs::read_to_string(&path).expect("read .claude/skills/ruchy-dogfood/SKILL.md");
+    let body = text
+        .strip_prefix("---\n")
+        .expect("SKILL.md must open with a --- frontmatter fence");
+    let end = body
+        .find("\n---\n")
+        .expect("SKILL.md frontmatter must be closed by ---");
+    body[..end].to_string()
+}
+
+#[test]
+fn test_pmat_136_skill_frontmatter_names_the_skill_and_allows_agent() {
+    let front = skill_frontmatter();
+    assert!(
+        front.lines().any(|l| l.trim() == "name: ruchy-dogfood"),
+        "SKILL.md needs an explicit `name: ruchy-dogfood`: a directory named dogfood is \
+         shadowed by the user-scope skill of the same name"
+    );
+    let tools = front
+        .lines()
+        .find(|l| l.starts_with("allowed-tools:"))
+        .expect("SKILL.md frontmatter must declare allowed-tools");
+    assert!(
+        tools.contains("Agent"),
+        "the protocol spawns three worker lanes, so Agent must be allowed: {tools}"
+    );
+}
+
+#[test]
+fn test_pmat_136_dogfood_gates_list_matches_the_declaration() {
+    let output = Command::new("bash")
+        .arg("scripts/dogfood-gates.sh")
+        .arg("--list")
+        .current_dir(repo_root())
+        .output()
+        .expect("run scripts/dogfood-gates.sh --list");
+    assert!(
+        output.status.success(),
+        "dogfood-gates.sh --list exited {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let listed: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(std::string::ToString::to_string)
+        .collect();
+    assert_eq!(
+        listed,
+        declared_gates(),
+        "--list must print exactly the gates declared in Cargo.toml"
+    );
+}


### PR DESCRIPTION
## Summary

`.claude/skills/ruchy-dogfood/SKILL.md` — the repo-scope, version-controlled pre-release protocol for the ruchy compiler, modelled on the fleet's dogfood v3 (explicit `name:` so a user-scope `dogfood` cannot shadow it; `Agent` in allowed-tools).

- Three read-only worker lanes with disjoint scopes, each writing one file: L1 CLI surface from the built binary + corpus coverage (`docs/audits/surface_audit.csv`, `out/lane-1.json`); L2 the book/examples corpus through the binary (`out/lane-2.json`); L3 wasm32 build + fresh-container install (`out/lane-3.json`; the install lane's subject is a later phase before publish and records `not-yet-measured`, never PASS).
- The orchestrator is the single receipt writer (`.dogfood/receipt-<sha>.json`, written as .partial and renamed); a lane `.err` or a missing lane file is NO-GO; `pmat work show` absent (pmat 3.38.0 has no such verb) is a FAIL row, not a skip; `--twice` must produce byte-identical receipts.
- Repo-specific gates are discovered from `[package.metadata.dogfood] gates` in Cargo.toml and run by `scripts/dogfood-gates.sh`, one row each; declared-but-missing is FAIL, empty is FAIL. Declared: `scripts/release-policy.sh` (PMAT-135, #219), `scripts/wasm32-build.sh`, `scripts/book-corpus.sh`.
- Tests (`dogfood_gates_declared`, 5) and `contracts/dogfood-gates-v1.yaml` (pv validate/lint clean). Measured: wasm32-build exit 0; book-corpus dry run 734 files, no missing corpora.

Depends on #219 for the first declared gate; until it merges `scripts/dogfood-gates.sh` reports that script as `FAIL … missing` by design (the allowlist in the test names PMAT-135 and empties itself once the file lands).

Pmat-Ticket: PMAT-136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
