### PR TITLE
fix(gate): the extracted crate is its own workspace root; a stray manifest above the work dir no longer sinks the clean-room [PMAT-139]

### DIFF
--- a/scripts/pre-release-gate.sh
+++ b/scripts/pre-release-gate.sh
@@ -639,6 +639,16 @@ crate_version() {
         gsub(/^version[[:space:]]*=[[:space:]]*"/, ""); gsub(/"$/, ""); print; exit }' "$ROOT/Cargo.toml"
 }
 
+# The extracted crate becomes its own workspace root. Cargo searches upward from a
+# manifest for a workspace; a stray Cargo.toml anywhere above $WORK (a fixture left
+# in /tmp made both clean-room builds die with "failed to parse manifest at
+# /tmp/Cargo.toml" on a tree the org clean-room passed 10/10, PMAT-139) would be
+# found and parsed. crates.io consumers never see a parent manifest, so an empty
+# [workspace] table changes nothing about what is measured.
+own_workspace_root() {
+    printf '\n[workspace]\n' >> "$1/Cargo.toml"
+}
+
 stage_clean_room() {
     hdr "STAGE 5/8  clean_room -- cargo package, then --locked and unlocked builds"
     local version
@@ -697,6 +707,7 @@ stage_clean_room() {
         return 0
     }
     local src="$ex/ruchy-$version"
+    own_workspace_root "$src"
 
     say "  clean-room build 1/2: --locked, fresh CARGO_HOME ..."
     local home1 locked_exit
@@ -724,6 +735,7 @@ stage_clean_room() {
     mkdir -p "$ex2"
     tar xzf "$crate" -C "$ex2"
     local src2="$ex2/ruchy-$version"
+    own_workspace_root "$src2"
     home2=$(mktemp -d "$WORK/cargohome2.XXXX")
     (cd "$src2" && env -u CARGO_TARGET_DIR CARGO_HOME="$home2" \
         cargo build --release) > "$WORK/cleanroom-unlocked.log" 2>&1


### PR DESCRIPTION
## Summary

The first dogfood run on the `v5.0.0-beta.2` tag checkout was a no-go for an environmental reason: a fixture `Cargo.toml` a worker test had left in `/tmp` sat above the gate's work directory, so cargo's upward workspace search parsed it (`missing field package.name`), both clean-room builds exited 101 and the `mutations` verb failed — on a tree the org clean-room had passed 10/10. Rerunning with `TMPDIR` under a manifest-free parent gave go.

The extracted crate now gets an empty `[workspace]` table, making it its own workspace root; crates.io consumers never have a parent manifest, so nothing measured changes.

**DoD (measured):** `./scripts/pre-release-gate.sh --only clean_room,package` with `TMPDIR=/mnt/nvme-raid0/tmp-gate-broken/work` and a broken `Cargo.toml` in `/mnt/nvme-raid0/tmp-gate-broken`: `clean_room` PASS (locked=0, unlocked=0, version 5.0.0-beta.2), `package` PASS. The same stages on the pre-fix script under `/tmp` with the stray file: exit 101 (`receipt-tmp-checkout-no-go-stray-manifest.json` in #221).

Pmat-Ticket: PMAT-139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
